### PR TITLE
Version 1.2.8

### DIFF
--- a/instagram/api/direct_messages.py
+++ b/instagram/api/direct_messages.py
@@ -491,7 +491,7 @@ class DirectChat:
             webbrowser.open(url)
             return None
 
-        save_dir = Config().get("advanced.media_dir")
+        save_dir = Path(Config().get("advanced.media_dir"))
         if not save_dir.exists():
             save_dir.mkdir(parents=True, exist_ok=True)
         # save_dir = configs.Config().get("advanced.media_dir", "media")
@@ -533,7 +533,7 @@ class DirectChat:
         - latex_expr: LaTeX expression to render.
         """
         # Save to the generated cahce
-        save_dir = Config().get("advanced.generated_dir")
+        save_dir = Path(Config().get("advanced.generated_dir"))
         if not save_dir.exists():
             save_dir.mkdir(parents=True, exist_ok=True)
 

--- a/instagram/api/utils.py
+++ b/instagram/api/utils.py
@@ -7,7 +7,7 @@ import time
 import json
 from pathlib import Path
 from uuid import uuid4
-
+import typer
 from instagram.configs import Config
 
 import instagrapi
@@ -426,12 +426,16 @@ def render_latex_local(latex_expr, output_path="latex_local.png", padding=None):
 
     return output_path
 
-def list_all_scheduled_tasks(username: str, filepath: str = None) -> list[dict]:
+def list_all_scheduled_tasks(filepath: str = None) -> list[dict]:
     """
-    List all scheduled tasks from the JSON file.
+    List all scheduled tasks for the current user from the JSON file.
     """
     if filepath is None:
-        filepath = Path(Config.get("users_dir")) / username / "tasks.json"
+        username = Config().get("login.current_username")
+        if not username:
+            typer.echo("You are not logged in. Please login first.\nSuggested action: `instagram auth login`")
+            return []
+        filepath = Path(Config().get("advanced.users_dir")) / username / "tasks.json"
     if not Path(filepath).exists():
         return []
     with open(filepath, "r") as f:

--- a/instagram/auth.py
+++ b/instagram/auth.py
@@ -1,6 +1,7 @@
 import typer
 from instagram.client import ClientWrapper, LoginRequired
 from instagram import configs
+from pathlib import Path
 
 def login() -> ClientWrapper:
     """Login to Instagram"""
@@ -42,3 +43,21 @@ def logout(un=None):
         typer.echo("Logged out.")
     except (LoginRequired, FileNotFoundError):
         typer.echo("Not logged in.")
+
+def switch_account(username):
+    """
+    Convenience function for Switching between multiple accounts
+
+    Functionally the same as:
+    ```
+    instagram ocnfig --set login.current_username <username>
+    ````
+    """
+    # Check if session exists
+    session_path = Path(configs.Config().get("advanced.users_dir")) / username / "session.json"
+    if not session_path.exists():
+        typer.echo(f"Cannot switch to @{username}. No session found.\nTry logging in with @{username} first.")
+        return
+    
+    configs.Config().set("login.current_username", username)
+    typer.echo(f"Switched to @{username}")

--- a/instagram/chat.py
+++ b/instagram/chat.py
@@ -36,7 +36,7 @@ def start_chat(username: str | None = None, search_filter: str = "") -> None:
     
     def init_chat(screen):
         # Initialize scheduler with screen for handling overdue messages (this is only done once)
-        path = Path(Config().get("users_dir")) / client.username / "tasks.json"
+        path = Path(Config().get("advanced.users_dir")) / client.username / "tasks.json"
         if not path.exists():
             path.parent.mkdir(parents=True, exist_ok=True)
             path.touch()

--- a/instagram/chat_ui/components/chat_window.py
+++ b/instagram/chat_ui/components/chat_window.py
@@ -40,7 +40,7 @@ class ChatWindow:
             is_selected = (msg_idx == self.selection and self.mode == ChatMode.REPLY)
 
             # Determine color index
-            if Config().get("chat.color") == "on":
+            if Config().get("chat.colors") == True:
                 color_idx = (hash(msg.message.sender) % 3) + 4
             else:
                 color_idx = 0  # no color

--- a/instagram/cli.py
+++ b/instagram/cli.py
@@ -26,7 +26,7 @@ def main(ctx: typer.Context):
 
     try:
         from importlib.metadata import version
-        cli_version = version("instagram")
+        cli_version = version("instagram-cli")
     except ImportError:
         cli_version = "Unknown"
 

--- a/instagram/cli.py
+++ b/instagram/cli.py
@@ -58,6 +58,18 @@ def logout(username: str = typer.Option(None, "-u", "--username")):
     """Logout from Instagram"""
     auth.logout(username)
 
+@auth_app.command()
+def switch_account(
+    username: str = typer.Argument(
+        ...,  # ... means the argument is required
+        help="Username of the account to switch to"
+    )
+):
+    """
+    Convenience command for Switching between multiple accounts
+    """
+    auth.switch_account(username)
+
 @chat_app.command()
 def start(ctx: typer.Context):
     """Open chat UI"""
@@ -129,10 +141,11 @@ def config(
     get: str = typer.Option(None, "-g", "--get", help="Get config value"),
     set: tuple[str, str] = typer.Option(None, "-s", "--set", help="Set config value"),
     list: bool = typer.Option(False, "-l", "--list", help="List all config values"),
-    edit: bool = typer.Option(False, "-e", "--edit", help="Open config file in default editor")
+    edit: bool = typer.Option(False, "-e", "--edit", help="Open config file in default editor"),
+    reset: bool = typer.Option(False, "-R", "--reset", help="Reset configuration to default")
 ):
     """Manage Instagram CLI configuration"""
-    configs.config(get, set, list, edit)
+    configs.config(get, set, list, edit, reset)
 
 @app.command()
 def cleanup(d_all: bool = typer.Option(True, "-a", "--all", help="Cleanup cache and temporary files")):

--- a/instagram/client.py
+++ b/instagram/client.py
@@ -146,7 +146,7 @@ def cleanup(delete_all: bool) -> None:
     session.delete_session()
     typer.echo("Session file cleaned up")
 
-    if delete_all:
+    if not delete_all:
         return
 
     cache_dir = Path(Config().get("advanced.cache_dir")).expanduser()

--- a/instagram/configs.py
+++ b/instagram/configs.py
@@ -117,9 +117,15 @@ def config(
     get: Optional[str] = typer.Option(None, "--get", help="Get config value"),
     set: Optional[tuple[str, str]] = typer.Option(None, "--set", help="Set config value"),
     list: bool = typer.Option(False, "--list", help="List all config values"),
-    edit: bool = typer.Option(False, "--edit", help="Open config file in default editor")
+    edit: bool = typer.Option(False, "--edit", help="Open config file in default editor"),
+    reset: bool = False
 ):
     cfg = Config()
+
+    if reset:
+        cfg._save_config(DEFAULT_CONFIG)
+        typer.echo("Configuration reset to default")
+        return
 
     if edit:
         import os

--- a/instagram/configs.py
+++ b/instagram/configs.py
@@ -12,7 +12,7 @@ DEFAULT_CONFIG = {
     },
     "chat": {
         "layout": "compact",
-        "colors": "on"
+        "colors": True
     },
     "scheduling": {
         "default_schedule_duration": "01:00"  # 1 hour

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagram-cli"
-version = "1.2.7"
+version = "1.2.8"
 description = "Use Instagram in the terminal, the end of brainrot is here"
 authors = [
     { name = "Jet Chiang", email = "jetjiang.ez@gmail.com" },


### PR DESCRIPTION
This PR mainly unifies the configurations across the app to `Config` class.
It also introduces minor new commands.

## New Commands
- `instagram config --reset`: reset all configurations to default.
- `instagram auth switch-account <username>`: Convenience command for switching between different logged-in accounts (so the user doesn't have to type `instagram config --set login.current_username <username>`). The first command also performs basic input validation.

## Code Changes
- `instagram.configs.Config` is reimplemented as a singleton class. Example usage is as follows:
    ```
    # No need to create a new Config instance
    Config().get("chat.layout")  # e.g. returns 'compact'
    Config().set("login.default_username", "george")  # The updated value will be immediately available in the next call to Config() from any interface 
    ```