### PR TITLE
Delay & cancelling message, CLI display, auth login fix

### DIFF
--- a/instagram/__init__.py
+++ b/instagram/__init__.py
@@ -5,4 +5,4 @@ from .client import cleanup
 
 __all__ = ["login", "logout", "start_chat", "Config", "cleanup"]
 
-__version__ = "1.3.1"
+__version__ = "1.3.3"

--- a/instagram/api/__init__.py
+++ b/instagram/api/__init__.py
@@ -1,7 +1,8 @@
 from .analytics import show_updates, analytics_bar_graph
 from .direct_messages import DirectMessages, DirectChat, MessageInfo, DirectThreadNotFound
 from .scheduler import MessageScheduler
-from .utils import list_all_scheduled_tasks
+from .utils import list_all_scheduled_tasks, cancel_scheduled_task_by_index
 
 __all__ = ["show_updates", "analytics_bar_graph", "DirectMessages",
-           "DirectChat", "MessageInfo", "MessageScheduler", "list_all_scheduled_tasks", "DirectThreadNotFound"]
+           "DirectChat", "MessageInfo", "MessageScheduler", "list_all_scheduled_tasks", 
+           "cancel_scheduled_task_by_index", "DirectThreadNotFound"]

--- a/instagram/api/direct_messages.py
+++ b/instagram/api/direct_messages.py
@@ -474,6 +474,13 @@ class DirectChat:
         """
         scheduler = MessageScheduler().get_instance()
         return scheduler.add_task(self.thread_id, send_time, message, display_name=self.get_title())
+
+    def cancel_latest_scheduled_message(self) -> str:
+        """
+        Cancel the latest scheduled message.
+        """
+        scheduler = MessageScheduler().get_instance()
+        return scheduler.cancel_latest_task()
     
     def get_message_id(self, message_index: int) -> str:
         """

--- a/instagram/api/scheduler.py
+++ b/instagram/api/scheduler.py
@@ -212,6 +212,14 @@ class MessageScheduler:
 
         self.remove_task(task)
 
+    def cancel_latest_task(self) -> str:
+        """Cancel the latest scheduled task."""
+        if self.tasks:
+            task = self.tasks[-1]
+            self.remove_task(task)
+            return f"Cancelled task for {task['send_time']}"
+        return "Error: No tasks to cancel."
+
     def remove_task(self, task: dict) -> None:
         """Remove a task."""
         if task in self.tasks:

--- a/instagram/api/utils.py
+++ b/instagram/api/utils.py
@@ -490,7 +490,34 @@ def list_all_scheduled_tasks(filepath: str = None) -> list[dict]:
             typer.echo("You are not logged in. Please login first.\nSuggested action: `instagram auth login`")
             return []
         filepath = Path(Config().get("advanced.users_dir")) / username / "tasks.json"
+
     if not Path(filepath).exists():
         return []
+
     with open(filepath, "r") as f:
         return json.load(f)
+
+def cancel_scheduled_task_by_index(index: int, filepath: str = None) -> str:
+    """
+    Cancel a scheduled task by index from the JSON file.
+    NOTE: This does not need to involve the scheduler itself because
+    on scheduler startup it will then load the new JSON tasks.
+    """
+    if filepath is None:
+        username = Config().get("login.current_username")
+        if not username:
+            typer.echo("You are not logged in. Please login first.\nSuggested action: `instagram auth login`")
+            return "You are not logged in. Please login first."
+        filepath = Path(Config().get("advanced.users_dir")) / username / "tasks.json"
+
+    tasks = list_all_scheduled_tasks(filepath)
+
+    if index < 0 or index >= len(tasks):
+        return "Invalid index. No task was cancelled."
+
+    tasks.pop(index)
+
+    with open(filepath, "w") as f:
+        json.dump(tasks, f, indent=4)
+
+    return f"Cancelled task at index {index}."

--- a/instagram/auth.py
+++ b/instagram/auth.py
@@ -1,54 +1,107 @@
 import typer
+from rich.progress import Progress, SpinnerColumn, TextColumn
 from instagram.client import ClientWrapper, LoginRequired
 from instagram import configs
 from pathlib import Path
 
+def _with_spinner(action: str, func, *args, **kwargs):
+    """Helper function to run an operation with a spinner"""
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        transient=True,
+    ) as progress:
+        progress.add_task(description=action, total=None)
+        return func(*args, **kwargs)
+
 def login() -> ClientWrapper:
     """Login to Instagram"""
-    typer.echo("Logging in")
-    client = ClientWrapper()
+    config = configs.Config()
+    current_username = config.get("login.current_username", None)
+    
+    # If we have a current username, try to use that first
+    client = ClientWrapper(current_username)
     try:
-        client.login_by_session()
+
+        _with_spinner(
+            f"Attempting to login by session...",
+            client.login_by_session,
+        )
+
+        typer.echo(f"Logged in as {client.username}")
+        return client
     except (LoginRequired, FileNotFoundError):
+        # Session invalid or not found, proceed with new login
         typer.echo("Cannot log in via session, logging in with username and password.")
         username = typer.prompt("Username")
         password = typer.prompt("Password", hide_input=True)
         verification_code = ""
         if typer.confirm("Do you use 2FA (2 Factor Authentication) ?"):
-            verification_code=typer.prompt("Provide your verification code (From The Auth App, SMS not supported)") 
-        client.login(username, password, refresh_session=True, verification_code=verification_code)
-    if client:
-        typer.echo(f"Logged in as {client.username}")
-        return client
-    else:
-        typer.echo("Login failed.")
+            verification_code = typer.prompt("Provide your verification code (From The Auth App, SMS not supported)")
+        
+        # Wrap only the login operation with spinner
+        _with_spinner(
+            f"Logging in as {username} with password...",
+            client.login,
+            username,
+            password,
+            refresh_session=True,
+            verification_code=verification_code
+        )
+        
+        if client:
+            typer.echo(f"Logged in as {client.username}")
+            return client
+        else:
+            typer.echo("Login failed.")
 
 def login_by_username() -> ClientWrapper:
     """Login to Instagram using username and password"""
-    typer.echo("Logging in")
     username = typer.prompt("Username")
     password = typer.prompt("Password", hide_input=True)
     verification_code = ""
     if typer.confirm("Do you use 2FA (2 Factor Authentication) ?"):
-        verification_code=typer.prompt("Provide your verification code (From The Auth App, SMS not supported)") 
+        verification_code = typer.prompt("Provide your verification code (From The Auth App, SMS not supported)")
+    
     client = ClientWrapper(username)
-    client.login(username, password, refresh_session=True, verification_code=verification_code)
+    # Wrap only the login operation with spinner
+    _with_spinner(
+        f"Logging in as {username} with password...",
+        client.login,
+        username,
+        password,
+        refresh_session=True,
+        verification_code=verification_code
+    )
+    
     if client:
         typer.echo(f"Logged in as {client.username}")
         return client
     else:
         typer.echo("Login failed.")
 
-def logout(un=None):
+def logout(username=None):
     """Logout from Instagram"""
-    typer.echo("Logging out")
-    client = ClientWrapper(un)
-    try:
-        client.login_by_session()
-        client.logout()
-        typer.echo("Logged out.")
-    except (LoginRequired, FileNotFoundError):
-        typer.echo("Not logged in.")
+    # Get current username from config if none provided
+    if not username:
+        config = configs.Config()
+        username = config.get("login.current_username")
+    
+    if username:
+        client = ClientWrapper(username)
+        try:
+            client.login_by_session()
+            # Wrap logout operation with spinner
+            _with_spinner(f"Logging out {username}...", client.logout)
+            # Clear both current and default username if they match
+            config = configs.Config()
+            if config.get("login.default_username") == username:
+                config.set("login.default_username", None)
+            typer.echo(f"Logged out @{username}.")
+        except (LoginRequired, FileNotFoundError):
+            typer.echo(f"@{username} not logged in.")
+    else:
+        typer.echo("No active session found.")
 
 def switch_account(username):
     """

--- a/instagram/chat_ui/utils/chat_commands.py
+++ b/instagram/chat_ui/utils/chat_commands.py
@@ -1,11 +1,6 @@
-# from datetime import datetime
-# import threading
-# import time
 import os
 import subprocess
 from datetime import datetime, timedelta
-# import tempfile
-# from typing import List, Tuple
 
 import tkinter as tk
 from tkinter import filedialog
@@ -160,7 +155,7 @@ def scroll_up(context) -> str:
 def scroll_down(context) -> str:
     return "__SCROLL_DOWN__"
 
-@cmd_registry.register("schedule", "Schedule a message to be sent at a later time, MUST BE 24-hour format", required_args=["time", "message"], shorthand="S")
+@cmd_registry.register("schedule", "Schedule a message to be sent at HH:MM (24 hour format)", required_args=["time", "message"], shorthand="S")
 def schedule_message(context, time: str, message: str) -> str:
     """
     Schedule a message to be sent at a later time.

--- a/instagram/chat_ui/utils/chat_commands.py
+++ b/instagram/chat_ui/utils/chat_commands.py
@@ -3,7 +3,7 @@
 # import time
 import os
 import subprocess
-from datetime import datetime
+from datetime import datetime, timedelta
 # import tempfile
 # from typing import List, Tuple
 
@@ -182,6 +182,37 @@ def schedule_message(context, time: str, message: str) -> str:
         return chat.schedule_message(time, message)
     except Exception as e:
         return f"Failed to schedule message: {e}"
+    
+@cmd_registry.register("cancel", "Cancel the LATEST scheduled message", required_args=[], shorthand="C")
+def cancel_latest_message(context) -> str:
+    """
+    Cancel a scheduled message.
+    """
+    chat: DirectChat = context["chat"]
+    try:
+        return chat.cancel_latest_scheduled_message()
+    except Exception as e:
+        return f"Failed to cancel scheduled message: {e}"
+
+@cmd_registry.register("delay", "Delay the chat interface for a specified time", required_args=["seconds", "message"], shorthand="d")
+def delay_sending_message(context, seconds: str, message:str) -> str:
+    """
+    Delay sending the message for a specified time using the scheduler as backend.
+    """
+    chat: DirectChat = context["chat"]
+    try:
+        # First check if the time is in the correct format
+        if int(seconds) < 0:
+            return "Invalid time format. Please use a positive integer for seconds"
+        
+        # Convert this into a future datetime compatible with the scheduler
+        future_time = datetime.now() + timedelta(seconds=int(seconds))
+        future_time = future_time.strftime("%Y-%m-%d %H:%M:%S")
+
+        # Schedule the message
+        return chat.schedule_message(future_time, message)
+    except Exception as e:
+        return f"Failed to delay message: {e}"
 
 @cmd_registry.register("help", "Show available commands", shorthand="h")
 def show_help(context) -> str:

--- a/instagram/cli.py
+++ b/instagram/cli.py
@@ -8,23 +8,26 @@ auth_app = typer.Typer()
 chat_app = typer.Typer()
 schedule_app = typer.Typer()
 
-"""Base command: Displays name, slogan, and visuals."""
 @app.callback(invoke_without_command=True)
 def main(ctx: typer.Context,
-         version: bool = typer.Option(False, "--version", "-v", help="Show version information", is_flag=True)):
-    
+         version: bool = typer.Option(False, "--version", "-v",
+                                      help="Show version information",
+                                      is_flag=True)):
+    """
+    Base command: Displays name, slogan, and visuals.
+    """
     # If the command is just 'instagram' without any subcommands
     if ctx.invoked_subcommand is not None:
         return
-    
+
     if version:
         typer.echo(f"InstagramCLI v{__version__}")
         return
-    
+
     # tprint("InstagramCLI", font="random")
-    
+
     logo = text2art("InstagramCLI")
-    
+
     typer.echo(f"\033[95m{logo}\033[0m")  # Magenta text
     typer.echo("\033[92mThe end of brainrot and doomscrolling is here.\033[0m")  # Green text
 
@@ -40,10 +43,10 @@ def main(ctx: typer.Context,
         typer.echo(f"{color}{msg}\033[0m")
         # time.sleep(0.5)  # Simulate loading effect
 
-# These are the subcommands
 @auth_app.command()
 def login(
-    use_username: bool = typer.Option(False, "-u", "--username", help="Login using username/password"),
+    use_username: bool = typer.Option(False, "-u", "--username",
+                                      help="Login using username/password"),
 ):
     """Login to Instagram"""
     try:
@@ -62,7 +65,7 @@ def logout(username: str = typer.Option(None, "-u", "--username")):
 @auth_app.command()
 def switch(
     username: str = typer.Argument(
-        ...,  # ... means the argument is required
+        ...,  # mark argument as required
         help="Username of the account to switch to"
     )
 ):
@@ -144,7 +147,8 @@ def config(
     configs.config(get, set, list, edit, reset)
 
 @app.command()
-def cleanup(d_all: bool = typer.Option(True, "-a", "--all", help="Cleanup cache and temporary files")):
+def cleanup(d_all: bool = typer.Option(False, "-a", "--all",
+                                    help="Cleanup cache and temporary files")):
     """Cleanup cache and temporary files"""
     client.cleanup(d_all)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagram-cli"
-version = "1.3.1"
+version = "1.3.3"
 description = "Use Instagram in the terminal, the end of brainrot is here"
 authors = [
     { name = "Jet Chiang", email = "jetjiang.ez@gmail.com" },


### PR DESCRIPTION
**[UEP] 1.3.3**: Fixes minor technical debts regarding the scheduler functionalities and consolidated CLI output display using `rich` (comes with `typer`, no extra dependencies introduced). 

> NOTE: We cannot ship v1.3.3 until the `instagrapi` issue in #63 is resolved

## New features
- Loading spinner for login logout using `rich.Spinner`
- Display schedule tasks with `rich.Table` instead of raw text manipulation
- Added the following chat commands #59 
  - New command to delay messages using Scheduler as backend: `:delay seconds "message"` (compared to the existing `:schedule HH:MM / YYYY:MM:DD HH:MM "message"` this is shorter and more user friendly
  - New command to cancel latest scheduled message `:cancel`
- Added the following CLI command:
   - `instagram scheduler cancel <index>`, you can obtain the index from `instagram scheduler ls` which lists all scheduled messages
   - The decision against chat command for cancelling scheduled tasks is because it will result in considerable "risky" chat UI changes and will make UX worse

## Code Changes
- New API to wrap `Scheduler` for `DirectMessages`, new commands

## Bug fixes
- Login issue in #62 which is persistent and happens due to some wrong config check workflow
