### PR TITLE
fix image download extension matching

### DIFF
--- a/instagram/api/direct_messages.py
+++ b/instagram/api/direct_messages.py
@@ -613,17 +613,12 @@ class DirectChat:
         filename = f"{media_item['media_id']}"
 
         try:
-            if media_item["media_type"] in ['photo', 'image']:
-                file_path = client.photo_download_by_url(
-                    media_item['url'],
-                    filename=filename, # apparently it does not require the .jpg extension
-                    folder=save_dir
-                )
-            elif media_item["media_type"] in ['video']:
-                file_path = client.video_download_by_url(
-                    media_item['url'],
+            if media_item["media_type"] in ['photo', 'image', 'video']:
+                file_path = download_media_by_url(
+                    url=media_item['url'],
                     filename=filename,
-                    folder=save_dir
+                    folder=save_dir,
+                    media_type=media_item["media_type"]
                 )
             else:
                 raise ValueError(f"Unsupported media type for viewing: {media_item['type']}")


### PR DESCRIPTION
Fixes #68 by rewriting the download logic in `DownloadPhotoMixin.photo_download_by_url` (in `instagrapi/mixins/photo.py`) to explicitly handle extension checking (and defaulting to '.jpg' for images). This avoids situations where an unnecessary "." was added to the end of the file when the file does not have extension.

I noted that by simply passing in a filename like 'something.jpg' does not solve this problem so we had to rewrite the download function. The new interface also works with `video_download_by_url` since they pretty much use the same logic, I just replicated that as well to make it easier to maintain.