### PR TITLE
[Feature] Loading screen at activity dashboard

### DIFF
--- a/instagram/api/analytics.py
+++ b/instagram/api/analytics.py
@@ -6,7 +6,7 @@ from collections import Counter
 
 from instagram.utils.loading import with_loading_screen
 
-def fetch_updates():
+def fetch_updates() -> dict:
     """Fetches latest updates from Instagram and returns them."""
     cl = ClientWrapper().login_by_session()
     # Get latest updates
@@ -23,7 +23,7 @@ def fetch_updates():
     }
 
 
-def render_updates(stdscr):
+def render_updates(stdscr) -> None:
     """Render Instagram updates in a curses window."""
 
 

--- a/instagram/chat.py
+++ b/instagram/chat.py
@@ -18,7 +18,7 @@ from instagram.configs import Config
 
 from instagram.chat_ui.interface.chat_interface import ChatInterface
 from instagram.chat_ui.interface.chat_menu import ChatMenu
-from instagram.chat_ui.utils.loading import with_loading_screen
+from instagram.utils.loading import with_loading_screen
 from instagram.chat_ui.utils.types import Signal
 
 def start_chat(username: str | None = None, search_filter: str = "") -> None:
@@ -65,12 +65,12 @@ def main_loop(screen, client: ClientWrapper, username: str | None, search_filter
     dm = DirectMessages(client)
 
     if username is None:
-        with_loading_screen(screen, dm.fetch_chat_data, num_chats=20, num_message_limit=20)
+        with_loading_screen(screen, dm.fetch_chat_data, num_chats=20, num_message_limit=20, text='Loading chat data')
 
     while True:
         if username:
             try:
-                selected_chat = with_loading_screen(screen, search_chat_list, dm, username, search_filter)
+                selected_chat = with_loading_screen(screen, search_chat_list, 'Loading message', dm, username, search_filter)
             except DirectThreadNotFound as e: # catch the error thrown by the controller
                 typer.echo(e)
                 break

--- a/instagram/chat.py
+++ b/instagram/chat.py
@@ -70,7 +70,7 @@ def main_loop(screen, client: ClientWrapper, username: str | None, search_filter
     while True:
         if username:
             try:
-                selected_chat = with_loading_screen(screen, search_chat_list, 'Loading message', dm, username, search_filter)
+                selected_chat = with_loading_screen(screen, search_chat_list, f'Loading chat data for {username}', dm, username, search_filter)
             except DirectThreadNotFound as e: # catch the error thrown by the controller
                 typer.echo(e)
                 break

--- a/instagram/utils/loading.py
+++ b/instagram/utils/loading.py
@@ -3,12 +3,12 @@ import threading
 import time
 from typing import Callable
 
-def create_loading_screen(screen, stop_event: threading.Event):
+def create_loading_screen(screen, stop_event: threading.Event, text):
     """Create a loading screen with a spinning icon."""
     screen.clear()
     curses.curs_set(0)
     height, width = screen.getmaxyx()
-    loading_text = "Loading chat data..."
+    loading_text = text
     spinner = ['|', '/', '-', '\\']
     idx = 0
 
@@ -23,12 +23,11 @@ def create_loading_screen(screen, stop_event: threading.Event):
     screen.clear()
     screen.refresh()
 
-def with_loading_screen(screen, func: Callable, *args, **kwargs):
+def with_loading_screen(screen, func: Callable, text='Loading', *args, **kwargs):
     """Execute function while showing loading screen."""
     stop_event = threading.Event()
-    loading_thread = threading.Thread(target=create_loading_screen, args=(screen, stop_event))
+    loading_thread = threading.Thread(target=create_loading_screen, args=(screen, stop_event, text))
     loading_thread.start()
-
     try:
         result = func(*args, **kwargs)
     finally:


### PR DESCRIPTION
When entering the Activity Dashboard,  now a loading screen is displayed, just like this:

![image](https://github.com/user-attachments/assets/04cabd0c-bbe4-45ce-801e-634ebbcf11f4)

For making that I used the already existing loading.py script, but modified slightly  to gain more modularity and moved from chat_ui/utils it to a more general location.