### PR TITLE
Avoid config file and session file conflict with python client

### DIFF
--- a/instagram-ts/source/config.ts
+++ b/instagram-ts/source/config.ts
@@ -75,7 +75,7 @@ export class ConfigManager {
 
 	private constructor() {
 		this.configDir = DEFAULT_CONFIG.advanced.dataDir;
-		this.configFile = path.join(this.configDir, 'config.yaml');
+		this.configFile = path.join(this.configDir, 'config.ts.yaml');
 		this.config = {...DEFAULT_CONFIG};
 	}
 

--- a/instagram-ts/source/session.ts
+++ b/instagram-ts/source/session.ts
@@ -54,7 +54,7 @@ export class SessionManager {
 		}
 
 		const usersDir = this.configManager.get<string>('advanced.usersDir');
-		return path.join(usersDir, this.username, 'session-ts.json');
+		return path.join(usersDir, this.username, 'session.ts.json');
 	}
 
 	private async ensureSessionDir(): Promise<string> {


### PR DESCRIPTION
Currently both writes to `config.yaml` but this blocks using python client, this is a simple fix that just uses `config.ts.yaml` to keep things as closely together as possible 😄 