### PR TITLE
Post date and dynamic width

### DIFF
--- a/instagram-ts/source/commands/feed.tsx
+++ b/instagram-ts/source/commands/feed.tsx
@@ -23,7 +23,6 @@ type Props = {
 	args: zod.infer<typeof args>;
 };
 
-const width = 80;
 
 export default function Feed({args}: Props) {
 	const [status, setStatus] = React.useState<'loading' | 'ready' | 'error'>(
@@ -77,5 +76,5 @@ export default function Feed({args}: Props) {
 	if (status === 'error') {
 		return <Alert variant="error">❌ {error}</Alert>;
 	}
-	return <MediaView feedItems={feedItems} width={width} />;
+	return <MediaView feedItems={feedItems} />;
 }

--- a/instagram-ts/source/types/instagram.ts
+++ b/instagram-ts/source/types/instagram.ts
@@ -62,4 +62,5 @@ export interface FeedItem {
 	videoUrl?: string;
 	like_count: number;
 	comment_count: number;
+	// created_at: number;
 }

--- a/instagram-ts/source/types/instagram.ts
+++ b/instagram-ts/source/types/instagram.ts
@@ -62,5 +62,5 @@ export interface FeedItem {
 	videoUrl?: string;
 	like_count: number;
 	comment_count: number;
-	// created_at: number;
+	taken_at: number;
 }

--- a/instagram-ts/source/ui/views/MediaView.tsx
+++ b/instagram-ts/source/ui/views/MediaView.tsx
@@ -18,19 +18,23 @@ export default function MediaView({feedItems, width = 40}: Props) {
 				const images: string[] = [];
 
 				for (const item of feedItems) {
-					const url = item.image_versions2?.candidates?.[0]?.url;
-					if (url) {
-						const ascii = await convertImageToColorAscii(url, width);
-						console.log(ascii);
-						images.push(ascii);
+					const candidates = item.image_versions2?.candidates;
+					if (candidates?.length) {
+						for (const candidate of candidates) {
+							const url = candidate.url;
+							if (url) {
+								const ascii = await convertImageToColorAscii(url);
+								images.push(ascii);
+							}
+						}
 					} else {
 						images.push('No image');
 					}
 				}
+
 				setAsciiImages(images);
 			} catch (err) {
 				console.error('Error converting images to ASCII:', err);
-			} finally {
 			}
 		};
 
@@ -49,6 +53,7 @@ export default function MediaView({feedItems, width = 40}: Props) {
 				>
 					<Text color="green">👤 {item.user?.username || 'Unknown user'}</Text>
 					<Text>{'\n'}</Text>
+					{/* <Text color="yellow">{new Date(item.created_at * 1000).toLocaleString()}</Text> */}
 					<Text>{item.caption?.text || 'No caption'}</Text>
 					<Text>{'\n'}</Text>
 

--- a/instagram-ts/source/ui/views/MediaView.tsx
+++ b/instagram-ts/source/ui/views/MediaView.tsx
@@ -9,37 +9,33 @@ type Props = {
 	width?: number;
 };
 
-export default function MediaView({feedItems, width = 40}: Props) {
+export default function MediaView({feedItems}: Props) {
 	const [asciiImages, setAsciiImages] = useState<string[]>([]);
 
-	useEffect(() => {
+useEffect(() => {
 		const renderAscii = async () => {
 			try {
 				const images: string[] = [];
 
 				for (const item of feedItems) {
-					const candidates = item.image_versions2?.candidates;
-					if (candidates?.length) {
-						for (const candidate of candidates) {
-							const url = candidate.url;
-							if (url) {
-								const ascii = await convertImageToColorAscii(url);
-								images.push(ascii);
-							}
-						}
+					const url = item.image_versions2?.candidates?.[0]?.url;
+					if (url) {
+						const ascii = await convertImageToColorAscii(url);
+						console.log(ascii);
+						images.push(ascii);
 					} else {
 						images.push('No image');
 					}
 				}
-
 				setAsciiImages(images);
 			} catch (err) {
 				console.error('Error converting images to ASCII:', err);
+			} finally {
 			}
 		};
 
 		renderAscii();
-	}, [feedItems, width]);
+	}, [feedItems]);
 
 	return (
 		<Box flexDirection="column" gap={1}>
@@ -51,9 +47,11 @@ export default function MediaView({feedItems, width = 40}: Props) {
 					borderStyle="round"
 					padding={1}
 				>
-					<Text color="green">👤 {item.user?.username || 'Unknown user'}</Text>
+					<Box flexDirection="row">
+						<Text color="green">👤 {item.user?.username || 'Unknown user'}</Text>
+						<Text color="gray">{' ('}{new Date(item.taken_at * 1000).toLocaleString()}{')'}</Text>
+					</Box>
 					<Text>{'\n'}</Text>
-					{/* <Text color="yellow">{new Date(item.created_at * 1000).toLocaleString()}</Text> */}
 					<Text>{item.caption?.text || 'No caption'}</Text>
 					<Text>{'\n'}</Text>
 
@@ -61,15 +59,15 @@ export default function MediaView({feedItems, width = 40}: Props) {
 						{/* TODO: Handling properly posts with multiple images */}
 						{asciiImages[index] ? (
 							asciiImages[index]
-								.split('\n')
-								.map((line, i) => <Text key={i}>{line}</Text>)
+							.split('\n')
+							.map((line, i) => <Text key={i}>{line}</Text>)
 						) : (
 							<Text color="yellow">⏳ Loading media...</Text>
 						)}
 					</Box>
 					<Box flexDirection="row">
-						<Text>♥ {item.like_count ?? 0} - </Text>
-						<Text>🗨 {item.comment_count ?? 0}</Text>
+						<Text>{' '}♡ {item.like_count ?? 0}{"   "}</Text>
+						<Text>🗨{"  "}{item.comment_count ?? 0}</Text>
 					</Box>
 				</Box>
 			))}

--- a/instagram-ts/source/utils/ascii-display.ts
+++ b/instagram-ts/source/utils/ascii-display.ts
@@ -31,16 +31,18 @@ function drawAsciiWithBorder(asciiArt: string, width: number): string {
 }
 
 function calculateDynamicAsciiWidth(imageWidth: number, imageHeight: number): number {
-	const termWidth = process.stdout.columns ?? 80;
-	const termHeight = process.stdout.rows ?? 24;
+	const termWidth = process.stdout.columns;
+	const termHeight = process.stdout.rows;
 
-	let width = Math.min(termWidth - 4, 120);
+	let width = Math.min(Math.floor(termWidth/3), 80);
 
 	const aspectRatio = imageWidth / imageHeight;
 
-	if (aspectRatio < 0.75 && termHeight < 40) {
-		width = Math.floor(width * 0.6);
-	} else if (aspectRatio > 1.5 && termWidth > 100) {
+	console.log('Term Width:', termWidth, 'Term Height:', termHeight, 'aspectRatio:', aspectRatio);
+
+	if (aspectRatio < 0.8) {
+		width = Math.floor(width * 0.7);
+	} else if (aspectRatio > 1.5) {
 		width = Math.floor(width * 1.1);
 	}
 
@@ -49,7 +51,6 @@ function calculateDynamicAsciiWidth(imageWidth: number, imageHeight: number): nu
 
 export async function convertImageToColorAscii(
 	imageUrl: string,
-	width: number = 100,
 ): Promise<string> {
 	try {
 		const buffer = await fetchImage(imageUrl);
@@ -68,7 +69,8 @@ export async function convertImageToColorAscii(
 		const imageWidth = metadata.width ?? 800;
 		const imageHeight = metadata.height ?? 600;
 
-		const finalWidth = width ?? calculateDynamicAsciiWidth(imageWidth, imageHeight);
+		const finalWidth = calculateDynamicAsciiWidth(imageWidth, imageHeight);
+		console.log('Final Width:', finalWidth, 'Image Width:', imageWidth, 'Image Height:', imageHeight);
 
 		const asciiArt = await AsciiArt.image({
 			filepath: finalPath,


### PR DESCRIPTION
I think there's still many things to be done to the feed visualizer but I expect to improve it little by little. The improvements this time are:

- The ASCII image is now rendered dynamically! Previously, it had a fixed width, but it now adapts to occupy up to roughly one-third of the terminal width. This prevents the ASCII art from overflowing or collapsing due to exceeding the terminal size. Additionally, a scaling factor is applied to portrait and landscape images to maintain comfortable proportions within the terminal
- The post timestamp is now also displayed.

TODO list:

- Properly display carousel posts (posts with more than one image)
- Displaying videos within the terminal is not an option, but probably adding a button for opening it on the browser?
- For development proposes, I think it would be a good idea making an utility for registering properties somewhere so we can check the properties later. If a new property that hast been registered is found, then its added automatically, so we can keep a track of all the possible properties. 
- Implement the list-type view I talked about before
- Explore any other way besides ASCII for displaying images (the display mode shall be selectable from the config)