### PR TITLE
[feature] chat history summarization and command result display

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ To limit (or expand) the summarization to the `n` most recent messages:
 :summarize n
 ```
 
+You can also turn on streaming mode with `instagram config --set llm.stream True` to see the summary being generated in real-time.
+
 > [!TIP]
 > If you don't mind giving your data to AI companies, you may set the `llama.endpoint` and `llm.model` configs to a remote endpoint, e.g. `https://api.openai.com/v1/`, `gpt-5`.
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,6 @@ The chat interface is the main feature of this package. It allows you to interac
 
 In the chat list page, use arrow keys (or 'j', 'k') + Enter to select a chat. You can also search for user by username using @user_name + Enter.
 
-> [!NOTE]
-> Chat commands (prefixed with `:`) are NOT available in the chat menu page. You must enter a chat to use chat commands.
-
 After entering the chat page, you can type messages as usual and send them with Enter. You can also use chat commands to supercharge your chat experience.
 
 > [!TIP]
@@ -136,10 +133,11 @@ All chat commands have the following syntax:
 - `:delay <seconds> "<message>"`: delay sending the message, similar as schedule
 - `:cancel`: cancel the latest scheduled/delayed message
 - `:upload`: upload media using the file navigator
-- `:upload <path>`: upload media (photo or video) directly from path
+- `:upload <path?>`: upload media (photo or video) directly from path
+- `:config <key?>=<value?>`: an in-chat version of `instagram config`
 - `:view <index>`: view and download media at index or open URL directly in browser
 - `:latex $<expr>$`: render and send LaTeX code as image, see [latex](#latex)
-- `:summarize`: generate a summary of chat history using an LLM, see [chat summarization](#chat-summarization)
+- `:summarize <depth?>`: generate a summary of chat history using an LLM, see [chat summarization](#chat-summarization)
 
 ### Emoji
 
@@ -151,7 +149,7 @@ will be rendered as
 
 `This is an emoji 👍`
 
-> ![TIP]
+> [!TIP]
 > This does not have to be an exact match with the emoji name. For example, `:thumbsup:` can also be written as `:thumbs_up:`.
 
 ### LaTeX
@@ -176,16 +174,17 @@ You can choose to render with [online API](https://latex.codecogs.com) (default)
 
 You can generate a summary of the chat history using the `:summarize` command. This will create a concise summary of the conversation, highlighting key points and important information.
 
-Local LLMs are first-class citizens here, allowing for maximum privacy and flexibility. All you need is a local LLM inferencing server like [Ollama](https://ollama.com/), [LM Studio](https://lmstudio.ai/).
-You can provide your own OpenAI-compatible endpoint for summarization by configuring the `llm.endpoint` setting. For example, for Ollama, this would likely be:
+Local LLMs are first-class citizens here, allowing for maximum privacy and flexibility. All you need is a local LLM inferencing server like [Ollama](https://ollama.com/), [LM Studio](https://lmstudio.ai/). You will need to specify `llm.endpoint` (OpenAI-compatible) and `llm.model` in the config. For example, for Ollama, this would likely be:
 
-```
+```plaintext
 http://localhost:11434/v1/
 ```
 
+You can do this with `instagram config --set llm.endpoint <URL>` and `instagram config --set llm.model <MODEL_NAME>`.
+
 Once inside a chat conversation, you can summarize the chat history using:
 
-```
+```plaintext
 :summarize
 ```
 
@@ -193,7 +192,7 @@ This will process all messages fetched in the current chat.
 
 To limit (or expand) the summarization to the `n` most recent messages:
 
-```
+```plaintext
 :summarize n
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ All chat commands have the following syntax:
 - `:upload <path>`: upload media (photo or video) directly from path
 - `:view <index>`: view and download media at index or open URL directly in browser
 - `:latex $<expr>$`: render and send LaTeX code as image, see [latex](#latex)
+- `:summarize`: generate a summary of chat history using an LLM, see [chat summarization](#chat-summarization)
 
 ### Emoji
 
@@ -170,6 +171,34 @@ We support LaTeX rendering and sending as images in the chat. For example,
 Please note that the LaTeX code **_MUST_** be enclosed in `$` symbols.
 
 You can choose to render with [online API](https://latex.codecogs.com) (default) or local LaTeX installation such as TeX Live, MiKTeX, etc. You can set the rendering method with `instagram config --set latex_rendering_method <online|local>`.
+
+### Chat Summarization
+
+You can generate a summary of the chat history using the `:summarize` command. This will create a concise summary of the conversation, highlighting key points and important information.
+
+Local LLMs are first-class citizens here, allowing for maximum privacy and flexibility. All you need is a local LLM inferencing server like [Ollama](https://ollama.com/), [LM Studio](https://lmstudio.ai/).
+You can provide your own OpenAI-compatible endpoint for summarization by configuring the `llm.endpoint` setting. For example, for Ollama, this would likely be:
+
+```
+http://localhost:11434/v1/
+```
+
+Once inside a chat conversation, you can summarize the chat history using:
+
+```
+:summarize
+```
+
+This will process all messages fetched in the current chat.
+
+To limit (or expand) the summarization to the `n` most recent messages:
+
+```
+:summarize n
+```
+
+> [!TIP]
+> If you don't mind giving your data to AI companies, you may set the `llama.endpoint` and `llm.model` configs to a remote endpoint, e.g. `https://api.openai.com/v1/`, `gpt-5`.
 
 ### Scheduling Messages
 

--- a/instagram/chat_ui/components/chat_window.py
+++ b/instagram/chat_ui/components/chat_window.py
@@ -31,7 +31,7 @@ class ChatWindow:
         """Set custom content to be displayed in the chat window."""
         self.custom_content = content
         self.update()
-    
+
     def clear_custom_content(self):
         """Clear custom content."""
         self.custom_content = None
@@ -152,12 +152,12 @@ class ChatWindow:
             content_lines = []
             for raw_line in self.custom_content.split("\n"):
                 while len(raw_line) > self.width:
-                    content_lines.append(raw_line[:self.width])
-                    raw_line = raw_line[self.width:]
+                    content_lines.append(raw_line[: self.width])
+                    raw_line = raw_line[self.width :]
                 content_lines.append(raw_line)
             # Only display up to available height
-            for i, line in enumerate(content_lines[:self.height]):
-                self.window.addstr(i, 0, line[:self.width])
+            for i, line in enumerate(content_lines[: self.height]):
+                self.window.addstr(i, 0, line[: self.width])
             self.window.refresh()
             return
 

--- a/instagram/chat_ui/components/chat_window.py
+++ b/instagram/chat_ui/components/chat_window.py
@@ -1,5 +1,5 @@
 import curses
-from typing import List
+from typing import List, Optional
 from ..utils.types import LineInfo, ChatMode
 from instagram.api import MessageInfo
 from instagram.configs import Config
@@ -20,11 +20,22 @@ class ChatWindow:
         self.scroll_offset = 0
         self.visible_messages_range = None
         self.visible_lines_range = None
+        self.custom_content: Optional[str] = None
 
     def set_messages(self, messages: List[MessageInfo]):
         """Update messages list."""
         self.messages = messages
         self._build_message_lines()
+
+    def set_custom_content(self, content: str):
+        """Set custom content to be displayed in the chat window."""
+        self.custom_content = content
+        self.update()
+    
+    def clear_custom_content(self):
+        """Clear custom content."""
+        self.custom_content = None
+        self.update()
 
     def _build_message_lines(self):
         """
@@ -133,7 +144,23 @@ class ChatWindow:
         - Basic word wrapping
         - Colored sender names
         - Replies and reactions
+
+        If custom content is set, it overrides the default message rendering.
         """
+        if self.custom_content:
+            self.window.erase()
+            content_lines = []
+            for raw_line in self.custom_content.split("\n"):
+                while len(raw_line) > self.width:
+                    content_lines.append(raw_line[:self.width])
+                    raw_line = raw_line[self.width:]
+                content_lines.append(raw_line)
+            # Only display up to available height
+            for i, line in enumerate(content_lines[:self.height]):
+                self.window.addstr(i, 0, line[:self.width])
+            self.window.refresh()
+            return
+
         if not self.messages:
             return
 

--- a/instagram/chat_ui/components/status_bar.py
+++ b/instagram/chat_ui/components/status_bar.py
@@ -38,7 +38,10 @@ class StatusBar:
             status_text = "[UNSEND] Use ↑↓ to select, Enter to confirm, Esc to exit"
         elif self.mode == ChatMode.COMMAND:
             self.window.bkgd(" ", curses.color_pair(2))
-            status_text = f"[COMMAND] Command {msg} executed. Press any key to continue"
+            status_text = f"[COMMAND] Executing command {msg if msg else '...'}"
+        elif self.mode == ChatMode.COMMAND_RESULT:
+            self.window.bkgd(" ", curses.color_pair(2))
+            status_text = "[COMMAND RESULT] Press any key to return to chat"
         else:
             status_text = "Georgian mode"
 

--- a/instagram/chat_ui/interface/chat_interface.py
+++ b/instagram/chat_ui/interface/chat_interface.py
@@ -227,7 +227,7 @@ class ChatInterface:
         # Show command execution status
         self.set_mode(ChatMode.COMMAND)
         self.status_bar.update(msg=command)
-        
+
         # Execute the command
         result = cmd_registry.execute(
             command, chat=self.direct_chat, screen=self.screen
@@ -397,7 +397,7 @@ class ChatInterface:
         # Handle command result mode - wait for any key press
         self.screen.get_wch()  # Wait for any key press
         self.chat_window.clear_custom_content()  # Clear content after display
-        
+
     def _handle_chat_message(self, message: str) -> Signal:
         """
         Send a chat message or reply to a selected message.

--- a/instagram/chat_ui/utils/chat_commands.py
+++ b/instagram/chat_ui/utils/chat_commands.py
@@ -366,7 +366,7 @@ def summarize_chat_history(context, depth: int = -1) -> str | Generator:
             "2. Any action items, decisions, or plans mentioned. "
             "The summary should be objective and focus on the content of the conversation. "
             "Write in a clear, concise style suitable for quick reading. "
-            "You must not try to format your output with bold or italics text. Do not use asterisks (*)."
+            "You must not try to format your output with bold or italics text. Do not use asterisks (*).",
         )
 
         # Configure OpenAI client

--- a/instagram/chat_ui/utils/chat_commands.py
+++ b/instagram/chat_ui/utils/chat_commands.py
@@ -358,13 +358,14 @@ def summarize_chat_history(context, depth: int = -1) -> str | Generator:
             conversation_text += "\n"
 
         # Create LLM request
-        system_prompt = (
+        system_prompt = config.get(
+            "llm.summary_system_prompt",
             "You are a helpful assistant that summarizes Instagram direct message conversations. "
             "Your task is to create a concise summary of the conversation that includes: "
             "1. The main topics discussed in the conversation. "
             "2. Any action items, decisions, or plans mentioned. "
             "The summary should be objective and focus on the content of the conversation. "
-            "Write in a clear, concise style suitable for quick reading."
+            "Write in a clear, concise style suitable for quick reading. "
             "You must not try to format your output with bold or italics text. Do not use asterisks (*)."
         )
 

--- a/instagram/chat_ui/utils/chat_commands.py
+++ b/instagram/chat_ui/utils/chat_commands.py
@@ -1,14 +1,12 @@
 import os
 import subprocess
-import json
 from datetime import datetime, timedelta
-from typing import List
 
 import tkinter as tk
 from tkinter import filedialog
 import openai
 from .commands import CommandRegistry
-from instagram.api import DirectChat, DirectThreadNotFound
+from instagram.api import DirectChat
 from instagram.configs import Config
 
 cmd_registry = CommandRegistry()
@@ -259,6 +257,7 @@ def delay_sending_message(context, seconds: str, message: str) -> str:
     except Exception as e:
         return f"Failed to delay message: {e}"
 
+
 @cmd_registry.register(
     "summarize",
     "Summarize the chat history",
@@ -271,7 +270,7 @@ def summarize_chat_history(context, depth: int = -1) -> str:
     Parameters:
     - depth (int): The depth of the summary (how many messages to include).
       Setting to -1 means including all messages.
-    
+
     TODO: Handle media and maybe send them to the LLM too
     """
     chat: DirectChat = context["chat"]
@@ -287,7 +286,7 @@ def summarize_chat_history(context, depth: int = -1) -> str:
                 raise ValueError
         except ValueError:
             return "Invalid depth value. Please provide a valid integer."
-    
+
     if depth > message_count:
         chat.fetch_chat_history(depth)
         messages, media = chat.get_chat_history()
@@ -296,7 +295,7 @@ def summarize_chat_history(context, depth: int = -1) -> str:
 
     if not messages:
         return "No messages found to summarize."
-    
+
     try:
         # Get config values
         config = Config()
@@ -305,33 +304,35 @@ def summarize_chat_history(context, depth: int = -1) -> str:
         model = config.get("llm.model")
         temperature = float(config.get("llm.temperature", 0.7))
         max_tokens = int(config.get("llm.max_tokens", 1000))
-        
+
         if not endpoint:
             return "LLM endpoint not configured. Set it using: /config llm.endpoint=URL"
-        
+
         # Format messages for the LLM
         chat_title = chat.get_title()
-        
+
         # Convert chat history to formatted text
         conversation_text = f"Chat title: {chat_title}\n\n"
-        
+
         for msg_info in messages[start_index:]:
             sender = msg_info.message.sender
             content = msg_info.message.content
-            
+
             if msg_info.reply_to:
                 reply_sender = msg_info.reply_to.sender
                 reply_content = msg_info.reply_to.content
                 conversation_text += f"{sender} (replying to {reply_sender}'s '{reply_content}'): {content}\n"
             else:
                 conversation_text += f"{sender}: {content}\n"
-            
+
             if msg_info.reactions:
-                reaction_text = ", ".join([f"{user}: {emoji}" for user, emoji in msg_info.reactions.items()])
+                reaction_text = ", ".join(
+                    [f"{user}: {emoji}" for user, emoji in msg_info.reactions.items()]
+                )
                 conversation_text += f"[Reactions: {reaction_text}]\n"
-                
+
             conversation_text += "\n"
-        
+
         # Create LLM request
         system_prompt = (
             "You are a helpful assistant that summarizes Instagram direct message conversations. "
@@ -342,7 +343,7 @@ def summarize_chat_history(context, depth: int = -1) -> str:
             "Write in a clear, concise style suitable for quick reading."
             "You must not try to format your output with bold or italics text. Do not use asterisks (*)."
         )
-        
+
         # Configure OpenAI client
         openai.base_url = endpoint
         if api_key:
@@ -356,17 +357,21 @@ def summarize_chat_history(context, depth: int = -1) -> str:
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
-                {"role": "user", "content": f"Here is the conversation to summarize:\n\n{conversation_text}"}
+                {
+                    "role": "user",
+                    "content": f"Here is the conversation to summarize:\n\n{conversation_text}",
+                },
             ],
             temperature=temperature,
             max_tokens=max_tokens,
         )
-        
+
         summary = response.choices[0].message.content.strip()
         return f"Chat Summary for: {chat_title}\n\n{summary}"
-    
+
     except Exception as e:
         return f"Failed to summarize chat: {str(e)}"
+
 
 @cmd_registry.register("help", "Show available commands", shorthand="h")
 def show_help(context) -> str:

--- a/instagram/chat_ui/utils/commands.py
+++ b/instagram/chat_ui/utils/commands.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Generator
 from dataclasses import dataclass
 import inspect
 import re
@@ -45,7 +45,7 @@ class CommandRegistry:
 
         return decorator
 
-    def execute(self, command_str: str, **context) -> str:
+    def execute(self, command_str: str, **context) -> str | Generator:
         """Execute a command string"""
         parsed = self.parse_command(command_str)
         if isinstance(parsed, str):

--- a/instagram/chat_ui/utils/types.py
+++ b/instagram/chat_ui/utils/types.py
@@ -19,6 +19,7 @@ class ChatMode(Enum):
 
     CHAT = auto()
     COMMAND = auto()
+    COMMAND_RESULT = auto()
     REPLY = auto()
     UNSEND = auto()
 

--- a/instagram/configs.py
+++ b/instagram/configs.py
@@ -12,6 +12,13 @@ DEFAULT_CONFIG = {
         "default_schedule_duration": "01:00"  # 1 hour
     },
     "privacy": {"invisible_mode": False},
+    "llm": {
+        "endpoint": "http://localhost:11434/v1/",
+        "api_key": "",
+        "model": "gemma-3n-e4b",
+        "temperature": 0.7,
+        "max_tokens": 1000
+    },
     "advanced": {
         "debug_mode": False,
         "data_dir": str(pathlib.Path.home() / ".instagram-cli"),

--- a/instagram/configs.py
+++ b/instagram/configs.py
@@ -19,6 +19,15 @@ DEFAULT_CONFIG = {
         "temperature": 0.7,
         "max_tokens": 1000,
         "streaming": False,
+        "summary_system_prompt": (
+            "You are a helpful assistant that summarizes Instagram direct message conversations. "
+            "Your task is to create a concise summary of the conversation that includes: "
+            "1. The main topics discussed in the conversation. "
+            "2. Any action items, decisions, or plans mentioned. "
+            "The summary should be objective and focus on the content of the conversation. "
+            "Write in a clear, concise style suitable for quick reading. "
+            "You must not try to format your output with bold or italics text. Do not use asterisks (*)."
+        ),
     },
     "advanced": {
         "debug_mode": False,

--- a/instagram/configs.py
+++ b/instagram/configs.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
         "model": "gemma-3n-e4b",
         "temperature": 0.7,
         "max_tokens": 1000,
+        "streaming": False,
     },
     "advanced": {
         "debug_mode": False,

--- a/instagram/configs.py
+++ b/instagram/configs.py
@@ -86,9 +86,6 @@ class Config:
                 default_value = DEFAULT_CONFIG
                 for k in key.split("."):
                     default_value = default_value[k]
-                typer.echo(
-                    f"Warning: Config key '{key}' not found in config.yaml file, using default value: {default_value}"
-                )
                 return default_value
             except (KeyError, TypeError):
                 return default

--- a/instagram/configs.py
+++ b/instagram/configs.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIG = {
         "api_key": "",
         "model": "gemma-3n-e4b",
         "temperature": 0.7,
-        "max_tokens": 1000
+        "max_tokens": 1000,
     },
     "advanced": {
         "debug_mode": False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "emoji>=2.14.1",
     "requests>=2.32.3",
     "click<8.2.0",
+    "openai>=1.100.1",
     "windows-curses; platform_system=='Windows'",
 ]
 classifiers = [


### PR DESCRIPTION
## New Command
- `:summarize` (`:s`): Get message summary with local LLM
  - Uses a OpenAI-compatible http endpoint for inferencing. This is supported by major local LLM runners like Ollama, LM Studio, llama.cpp, etc. and also works for remote endpoints for flexibility.
  - New configuration values are added for configuring inference endpoints, model name temperature, etc.

## UI Changes
- Command results, e.g. those from `:help`, `:summarize` will be displayed and wait for key press before being dismissed. This is to prevent the issue of not having enough time to read long informational results before they time out (usually after a few seconds).