### PR TITLE
[hotfix] typescript publishing ci: npm version and permissions

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -11,6 +11,7 @@ on:
     types: [published]
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
 
 jobs:
@@ -21,10 +22,6 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ts-v')) ||
       (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'ts-v'))
 
-    permissions:
-      contents: read
-      id-token: write # Required for NPM provenance
-
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +30,10 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@i7m"
+
+      - name: Update npm
+        # Ensure npm 11.5.1 or later for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies and build
         working-directory: ./instagram-ts


### PR DESCRIPTION
This PR makes minor updates to the TypeScript publishing GitHub Actions workflow to make it work.

## Workflow security and compatibility improvements:

* Added `id-token: write` permission at the top-level, ensuring OIDC is enabled for the workflow, which is required for secure npm publishing.
* Removed redundant `permissions` block from the job definition, since permissions are now set globally.
* Added a step to update npm to the latest version (at least 11.5.1), which is necessary for trusted publishing support.
  **This is the crucial step without which trusted publishing will fail**