### PR TITLE
hotfix: use api instead of mqtt for sending messages

### DIFF
--- a/instagram-ts/package.json
+++ b/instagram-ts/package.json
@@ -104,7 +104,9 @@
 			"@typescript-eslint/no-empty-function": "off",
 			"react/no-array-index-key": "off",
 			"react/require-default-props": "off",
-			"unicorn/prevent-abbreviations": "off"
+			"unicorn/prevent-abbreviations": "off",
+			"capitalized-comments": "off",
+			"no-useless-return": "off"
 		}
 	},
 	"prettier": "@vdemedes/prettier-config"

--- a/instagram-ts/source/client.ts
+++ b/instagram-ts/source/client.ts
@@ -459,14 +459,14 @@ export class InstagramClient extends EventEmitter {
 	}
 
 	public async sendMessage(threadId: string, text: string): Promise<void> {
-		if (this.realtimeStatus === 'connected' && this.realtime?.direct) {
-			try {
-				await this.realtime.direct.sendText({threadId, text});
-				return;
-			} catch {
-				this.logger.warn('MQTT sendMessage failed, falling back to API.');
-			}
-		}
+		// if (this.realtimeStatus === 'connected' && this.realtime?.direct) {
+		// 	try {
+		// 		await this.realtime.direct.sendText({threadId, text});
+		// 		return;
+		// 	} catch {
+		// 		this.logger.warn('MQTT sendMessage failed, falling back to API.');
+		// 	}
+		// }
 
 		// Fallback to API if MQTT not available, failed, or not ready
 		try {

--- a/instagram-ts/source/ui/views/chat-view.tsx
+++ b/instagram-ts/source/ui/views/chat-view.tsx
@@ -54,7 +54,6 @@ export default function ChatView() {
 			};
 		}
 
-		// eslint-disable-next-line no-useless-return
 		return;
 	}, [systemMessage]);
 
@@ -399,7 +398,6 @@ export default function ChatView() {
 			setSystemMessage(errorMessage);
 		}
 
-		// eslint-disable-next-line no-useless-return
 		return;
 	};
 

--- a/instagram-ts/source/utils/chat-commands.ts
+++ b/instagram-ts/source/utils/chat-commands.ts
@@ -84,7 +84,6 @@ export const chatCommands: Record<string, ChatCommand> = {
 				selectedMessageIndex: undefined,
 			}));
 
-			// eslint-disable-next-line no-useless-return
 			return;
 		},
 	},
@@ -114,7 +113,6 @@ export const chatCommands: Record<string, ChatCommand> = {
 				selectedMessageIndex: undefined,
 			}));
 
-			// eslint-disable-next-line no-useless-return
 			return;
 		},
 	},
@@ -180,7 +178,6 @@ export const chatCommands: Record<string, ChatCommand> = {
 				messages: previous.messages.filter(m => m.id !== messageToUnsend.id),
 				selectedMessageIndex: undefined,
 			}));
-			// eslint-disable-next-line no-useless-return
 			return;
 		},
 	},
@@ -194,7 +191,6 @@ export const chatCommands: Record<string, ChatCommand> = {
 			const scrollAmount = Math.max(1, height * 0.75);
 			scrollViewRef.current.scrollTo(curr => curr - scrollAmount);
 
-			// eslint-disable-next-line no-useless-return
 			return;
 		},
 	},
@@ -209,7 +205,6 @@ export const chatCommands: Record<string, ChatCommand> = {
 
 			scrollViewRef.current.scrollTo(curr => curr + scrollAmount);
 
-			// eslint-disable-next-line no-useless-return
 			return;
 		},
 	},
@@ -222,7 +217,6 @@ export const chatCommands: Record<string, ChatCommand> = {
 
 			scrollViewRef.current.scrollToStart(false); // Don't load earlier messages
 
-			// eslint-disable-next-line no-useless-return
 			return;
 		},
 	},
@@ -235,7 +229,6 @@ export const chatCommands: Record<string, ChatCommand> = {
 
 			scrollViewRef.current.scrollToEnd(false); // Don't show scroll to bottom message
 
-			// eslint-disable-next-line no-useless-return
 			return;
 		},
 	},


### PR DESCRIPTION
As reported by several users, we have now identified and are investigating a phenomenon named "Schodinger's messages", namely when messages sent by the client via MQTT mainly is unstable and might not be received by other web clients. We suspect we are using an outdated MQTT endpoint so that the database is not syncing and this PR currently reverts to using API instead of realtime client for sending messages. See #171 

**This PR ONLY fixes issues with sending text, relies and reactions will be further investigated**