### PR TITLE
Add snap client

### DIFF
--- a/instagram-py/snap/snapcraft.yaml
+++ b/instagram-py/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ grade: stable
 confinement: strict
 
 apps:
-  instagram:
+  instagram-cli:
     command: bin/instagram
     plugs:
       - network


### PR DESCRIPTION
Added support to build the python client into a snap app (core24-based).
- added snap/snapcraft.yaml 

Binary can be built and run as follows:
```bash
~/instagram-cli/instagram-py $ snapcraft pack
~/instagram-cli/instagram-py $ sudo snap install instagram-cli_1.4.1_amd64.snap --dangerous
~/instagram-cli/instagram-py $ snap run instagram-cli
```
Binary can be published to snapstore

Closes #225