### PR TITLE
Fix: instagram version endpoint error

### DIFF
--- a/patches/instagram-private-api+1.46.1.patch
+++ b/patches/instagram-private-api+1.46.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/instagram-private-api/dist/core/constants.js b/node_modules/instagram-private-api/dist/core/constants.js
-index 1234567..abcdefg 100644
+index d4485a0..295427d 100644
 --- a/node_modules/instagram-private-api/dist/core/constants.js
 +++ b/node_modules/instagram-private-api/dist/core/constants.js
-@@ -1,7 +1,7 @@
+@@ -1,8 +1,8 @@
  "use strict";
  Object.defineProperty(exports, "__esModule", { value: true });
  exports.WEBHOST = exports.HOST = exports.WEB_HOSTNAME = exports.HOSTNAME = exports.BLOKS_VERSION_ID = exports.FACEBOOK_ORCA_APPLICATION_ID = exports.FACEBOOK_OTA_FIELDS = exports.FACEBOOK_ANALYTICS_APPLICATION_ID = exports.LOGIN_EXPERIMENTS = exports.EXPERIMENTS = exports.SIGNATURE_VERSION = exports.BREADCRUMB_KEY = exports.SIGNATURE_KEY = exports.APP_VERSION_CODE = exports.APP_VERSION = void 0;


### PR DESCRIPTION
<html>
<body>


<h2>Fix Instagram checkpoint_required error due to deprecated app version</h2>
<h3>Problem</h3>
<p>Login and API calls were failing with:</p>
<pre><code>checkpoint_required
checkpoint_url: https://i.instagram.com/web/unsupported_version/
</code></pre>
<p>Instagram deprecated the app version (<code>222.0.0.13.114</code>) that <code>instagram-private-api</code> emulates. When Instagram forces old app versions to upgrade, all sessions using that version get blocked.</p>
<h3>Solution</h3>
<p>Updated the emulated Instagram app version in <code>instagram-private-api</code>:</p>

Field | Old | New
-- | -- | --
APP_VERSION | 222.0.0.13.114 | 347.0.0.43.109
APP_VERSION_CODE | 350696709 | 614918025


<h3>Changes</h3>
<p>Updated <code>.patches</code> file:</p>
<pre><code class="language-diff">-exports.APP_VERSION = '222.0.0.13.114';
-exports.APP_VERSION_CODE = '350696709';
+exports.APP_VERSION = '347.0.0.43.109';
+exports.APP_VERSION_CODE = '614918025';
</code></pre>
<h3>After Merging</h3>
<p>Users will need to:</p>
<ol>
<li>
<p>Apply the patch:</p>
<pre><code class="language-bash">npm ci
</code></pre>
</li>
<li>
<p>Delete existing sessions:</p>
<pre><code class="language-bash">rm -rf ~/.instagram-cli/users/
</code></pre>
</li>
<li>
<p>Re-login:</p>
<pre><code class="language-bash">instagram-cli login -u &lt;username&gt;
</code></pre>
</li>
</ol>
</ul></body></html><!--EndFragment-->
</body>
</html>