### PR TITLE
release: ts-v1.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@i7m/instagram-cli",
-	"version": "1.4.3",
+	"version": "1.4.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@i7m/instagram-cli",
-			"version": "1.4.3",
+			"version": "1.4.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
 	"name": "@i7m/instagram-cli",
 	"description": "The unofficial CLI and terminal client for Instagram",
-	"version": "1.4.3",
+	"version": "1.4.4",
 	"license": "MIT",
 	"repository": {
-		"type": "git",
-		"url": "https://github.com/supreme-gg-gg/instagram-cli"
+		"url": "git+https://github.com/supreme-gg-gg/instagram-cli.git"
 	},
 	"keywords": [
 		"instagram",
@@ -42,7 +41,8 @@
 		"postinstall": "patch-package"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"patches"
 	],
 	"dependencies": {
 		"@inkjs/ui": "^2.0.0",


### PR DESCRIPTION
Patches were not included in previous builds because we switched to source-only distribution in #227 It wasn't a problem until an API patch became essential to functionality, brought it back in latest release 😄 