### PR TITLE
fix: restrict session file and directory permissions

### DIFF
--- a/source/session.ts
+++ b/source/session.ts
@@ -39,11 +39,10 @@ export class SessionManager {
 		try {
 			// Remove constants to always use the latest version
 			const {constants, ...stateToSave} = serializedState;
-			await fs.writeFile(
-				sessionPath,
-				JSON.stringify(stateToSave, null, 2),
-				'utf8',
-			);
+			await fs.writeFile(sessionPath, JSON.stringify(stateToSave, null, 2), {
+				encoding: 'utf8',
+				mode: 0o600,
+			});
 		} catch (error) {
 			this.logger.error('Error saving session:', error);
 			throw error;
@@ -128,7 +127,7 @@ export class SessionManager {
 
 		const usersDirectory = this.configManager.get('advanced.usersDir');
 		const sessionDirectory = path.join(usersDirectory, this.username);
-		await fs.mkdir(sessionDirectory, {recursive: true});
+		await fs.mkdir(sessionDirectory, {recursive: true, mode: 0o700});
 		return sessionDirectory;
 	}
 }

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import test from 'ava';
+import {SessionManager} from '../source/session.js';
+import {ConfigManager} from '../source/config.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const configManager = ConfigManager.getInstance();
+
+async function withTempUsersDir(
+	fn: (tmpDir: string) => Promise<void>,
+): Promise<void> {
+	await configManager.initialize();
+	const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ig-cli-test-'));
+	const originalUsersDir = configManager.get('advanced.usersDir');
+
+	try {
+		await configManager.set('advanced.usersDir', tmpDir);
+		await fn(tmpDir);
+	} finally {
+		await configManager.set('advanced.usersDir', originalUsersDir);
+		await fs.rm(tmpDir, {recursive: true, force: true});
+	}
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.serial(
+	'SessionManager: session file is written with owner-only permissions',
+	async t => {
+		await withTempUsersDir(async tmpDir => {
+			const manager = new SessionManager('test-user');
+			await manager.saveSession({test: 'data'});
+
+			const sessionPath = path.join(tmpDir, 'test-user', 'session.ts.json');
+			const stat = await fs.stat(sessionPath);
+
+			t.is(
+				stat.mode & 0o777,
+				0o600,
+				'Session file should be owner read/write only (0o600)',
+			);
+		});
+	},
+);
+
+test.serial(
+	'SessionManager: session directory is created with owner-only permissions',
+	async t => {
+		await withTempUsersDir(async tmpDir => {
+			const manager = new SessionManager('test-user-dir');
+			await manager.saveSession({test: 'data'});
+
+			const dirPath = path.join(tmpDir, 'test-user-dir');
+			const stat = await fs.stat(dirPath);
+
+			t.is(
+				stat.mode & 0o777,
+				0o700,
+				'Session directory should be owner-only (0o700)',
+			);
+		});
+	},
+);


### PR DESCRIPTION
Closes #273

## Problem

Session files (`session.ts.json`) contain the full serialized Instagram session — `sessionid`, `csrftoken`, `ds_user_id`, device fingerprint — enough to resume the session without knowing the password. They were being written with the process umask default (typically `0644`), making them world-readable on any shared or multi-user system.

## Fix

Two lines in `session.ts`:

- `writeFile` → `{encoding: 'utf8', mode: 0o600}` — owner read/write only
- `mkdir` → `{recursive: true, mode: 0o700}` — owner-only directory

## Tests

Added `tests/session.test.ts` with two `test.serial` cases (serial to avoid ConfigManager singleton race):

- Asserts session file is created with mode `0o600`
- Asserts session directory is created with mode `0o700`

All 83 existing tests continue to pass.

## Notes

- `mode` in `writeFile` only applies on file creation; existing session files on disk are unaffected (they'd need a one-time `chmod` on upgrade, which is out of scope for this fix)
- This does not affect `config.ts.yaml`, which is less sensitive and intentionally readable