### PR TITLE
fix: use grapheme-aware truncation for reply previews

### DIFF
--- a/source/ui/components/message-list.tsx
+++ b/source/ui/components/message-list.tsx
@@ -3,6 +3,7 @@ import {Box, Text} from 'ink';
 import Image from 'ink-picture';
 import type {Message, Thread} from '../../types/instagram.js';
 import {useImageProtocol} from '../hooks/use-image-protocol.js';
+import {truncateText} from '../../utils/text-utils.js';
 
 type MessageListProperties = {
 	readonly messages: Message[];
@@ -168,12 +169,7 @@ export default function MessageList({
 										</Text>
 										<Text dimColor>
 											{message.repliedTo.itemType === 'text'
-												? `"${message.repliedTo.text?.slice(0, 40) ?? ''}${
-														message.repliedTo.text &&
-														message.repliedTo.text.length > 40
-															? '...'
-															: ''
-													}"`
+												? `"${truncateText(message.repliedTo.text ?? '', 40)}"`
 												: `[A ${message.repliedTo.itemType}]`}
 										</Text>
 									</Box>

--- a/source/utils/text-utils.ts
+++ b/source/utils/text-utils.ts
@@ -1,0 +1,43 @@
+const segmenter = new Intl.Segmenter();
+
+/**
+ * Returns the number of grapheme clusters in a string.
+ *
+ * Unlike `String.prototype.length`, which counts UTF-16 code units, this
+ * correctly handles multi-codepoint characters (emoji, Arabic, Hindi,
+ * Vietnamese combining marks, etc.).
+ */
+export function graphemeLength(text: string): number {
+	return [...segmenter.segment(text)].length;
+}
+
+/**
+ * Truncates a string to at most `maxGraphemes` grapheme clusters, appending
+ * `suffix` when truncation occurs.
+ *
+ * Safe for all scripts: Arabic, Devanagari, Vietnamese combining characters,
+ * emoji, CJK, and all other Unicode ranges.
+ *
+ * @param text - The string to truncate.
+ * @param maxGraphemes - Maximum number of grapheme clusters to keep.
+ * @param suffix - Appended when the string is truncated. Defaults to `'...'`.
+ */
+export function truncateText(
+	text: string,
+	maxGraphemes: number,
+	suffix = '...',
+): string {
+	const iter = segmenter.segment(text)[Symbol.iterator]();
+	const kept: string[] = [];
+
+	for (let i = 0; i < maxGraphemes; i++) {
+		const {value, done} = iter.next();
+		if (done) return text; // at or under limit — return original
+		kept.push(value.segment);
+	}
+
+	// One more peek: if exhausted we're exactly at the limit, no suffix needed
+	if (iter.next().done) return text;
+
+	return kept.join('') + suffix;
+}

--- a/tests/text-utils.test.ts
+++ b/tests/text-utils.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+
+import test from 'ava';
+import {truncateText, graphemeLength} from '../source/utils/text-utils.js';
+
+// ── graphemeLength ────────────────────────────────────────────────────────────
+
+test('graphemeLength: ASCII string', t => {
+	t.is(graphemeLength('hello'), 5);
+});
+
+test('graphemeLength: emoji counts as one grapheme', t => {
+	t.is(graphemeLength('😀'), 1);
+	t.is(graphemeLength('😀😀'), 2);
+});
+
+test('graphemeLength: Arabic text with diacritics', t => {
+	// Each Arabic letter with combining marks is one grapheme cluster
+	const arabic = 'مرحبا'; // 5 base letters
+	t.is(graphemeLength(arabic), 5);
+});
+
+test('graphemeLength: Hindi (Devanagari) conjunct clusters', t => {
+	// 'क्ष' is two codepoints but one grapheme cluster (consonant + virama)
+	t.is(graphemeLength('क्ष'), 1);
+});
+
+// ── truncateText ──────────────────────────────────────────────────────────────
+
+test('truncateText: short string is returned unchanged', t => {
+	t.is(truncateText('hello', 10), 'hello');
+});
+
+test('truncateText: string at exact limit is returned unchanged', t => {
+	t.is(truncateText('hello', 5), 'hello');
+});
+
+test('truncateText: ASCII string over limit is truncated with suffix', t => {
+	t.is(truncateText('hello world', 5), 'hello...');
+});
+
+test('truncateText: custom suffix', t => {
+	t.is(truncateText('hello world', 5, '…'), 'hello…');
+});
+
+test('truncateText: empty suffix', t => {
+	t.is(truncateText('hello world', 5, ''), 'hello');
+});
+
+test('truncateText: emoji does not get split', t => {
+	// '😀😀😀' — 3 graphemes, limit 2 → keep 2 emoji, not split a codepoint
+	t.is(truncateText('😀😀😀', 2), '😀😀...');
+});
+
+test('truncateText: Arabic text does not corrupt combining marks', t => {
+	const arabic = 'مرحبا بالعالم'; // "Hello world" in Arabic
+	const result = truncateText(arabic, 5);
+
+	// Result must end with suffix and have exactly 5 graphemes before it
+	t.true(result.endsWith('...'));
+	t.is(graphemeLength(result.slice(0, -3)), 5);
+});
+
+test('truncateText: Vietnamese combining diacritics are preserved', t => {
+	// 'Xin chào' — 'à' in 'chào' is a base letter + combining grave + combining tone
+	const vietnamese = 'Xin chào thế giới';
+	const result = truncateText(vietnamese, 8);
+
+	t.true(result.endsWith('...'));
+	// No broken characters — each cluster boundary is respected
+	t.is(graphemeLength(result.slice(0, -3)), 8);
+});


### PR DESCRIPTION
Closes #268

## Problem

Reply previews in `message-list.tsx` used `.slice(0, 40)` to truncate text. JavaScript's `String.prototype.slice` counts UTF-16 code units — not grapheme clusters — so it splits multi-codepoint characters in Arabic, Devanagari, Vietnamese, and other complex scripts, producing corrupted/broken characters in the UI.

## Fix

Added `source/utils/text-utils.ts` with two exports:

- `graphemeLength(text)` — counts grapheme clusters via `Intl.Segmenter`
- `truncateText(text, maxGraphemes, suffix?)` — truncates at grapheme boundaries

Replaced the broken `.slice(0, 40)` + `.length > 40` check in `message-list.tsx` with a single `truncateText(text, 40)` call.

`Intl.Segmenter` is built into V8 (Node.js 16+) — no new dependencies.

## Tests

Added `tests/text-utils.test.ts` with 10 cases covering ASCII, emoji, Arabic, Devanagari conjuncts, and Vietnamese combining diacritics.

All 93 tests pass.