### PR TITLE
fix: delete key now removes character to the right of cursor

### DIFF
--- a/source/ui/components/text-input.tsx
+++ b/source/ui/components/text-input.tsx
@@ -111,12 +111,18 @@ export default function TextInput({
 						nextCursorOffset + 1,
 					);
 				}
-			} else if (key.backspace || key.delete) {
+			} else if (key.backspace) {
 				if (internalCursorOffset > 0) {
 					nextValue =
 						originalValue.slice(0, internalCursorOffset - 1) +
 						originalValue.slice(internalCursorOffset);
 					nextCursorOffset = internalCursorOffset - 1;
+				}
+			} else if (key.delete) {
+				if (internalCursorOffset < originalValue.length) {
+					nextValue =
+						originalValue.slice(0, internalCursorOffset) +
+						originalValue.slice(internalCursorOffset + 1);
 				}
 			} else {
 				nextValue =

--- a/tests/text-input.test.tsx
+++ b/tests/text-input.test.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import chalk from 'chalk';
+import React from 'react';
+import test from 'ava';
+import {render} from 'ink-testing-library';
+import InputBox from '../source/ui/components/input-box.js';
+import {MouseProvider} from '../source/ui/context/mouse-context.js';
+
+// Force chalk to emit ANSI color codes so cursor highlight is visible in
+// captured frame output. Must be set before any rendering occurs.
+chalk.level = 3;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const delay = async (ms: number): Promise<void> =>
+	new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
+
+const LEFT_ARROW = '\u001B[D';
+const DELETE_KEY = '\u001B[3~';
+const BACKSPACE = '\u0008';
+
+// ── Delete key tests ──────────────────────────────────────────────────────────
+
+test('delete key removes character to the right of cursor', async t => {
+	const {lastFrame, stdin} = render(
+		<MouseProvider>
+			<InputBox onSend={() => {}} />
+		</MouseProvider>,
+	);
+
+	// Type "ab", cursor ends at index 2
+	stdin.write('ab');
+	await delay(100);
+
+	// Move cursor one left: now at index 1 (on 'b')
+	stdin.write(LEFT_ARROW);
+	await delay(100);
+
+	// Delete removes char at index 1 ('b'), cursor stays at 1 (now the end)
+	stdin.write(DELETE_KEY);
+	await delay(100);
+
+	const frame = lastFrame()!;
+	// Value is now "a", cursor at end — rendered as "a" + inverse-space
+	t.true(
+		frame.includes('a\u001B[7m \u001B[27m'),
+		`Expected "a" with cursor at end but got: ${JSON.stringify(frame)}`,
+	);
+});
+
+test('delete key at end of string does nothing', async t => {
+	const {lastFrame, stdin} = render(
+		<MouseProvider>
+			<InputBox onSend={() => {}} />
+		</MouseProvider>,
+	);
+
+	stdin.write('hello');
+	await delay(100);
+
+	const frameBefore = lastFrame()!;
+
+	// Cursor is at end — nothing to the right
+	stdin.write(DELETE_KEY);
+	await delay(100);
+
+	t.is(lastFrame(), frameBefore);
+});
+
+test('backspace removes character to the left of cursor', async t => {
+	const {lastFrame, stdin} = render(
+		<MouseProvider>
+			<InputBox onSend={() => {}} />
+		</MouseProvider>,
+	);
+
+	// Type "ab", cursor ends at index 2
+	stdin.write('ab');
+	await delay(100);
+
+	// Move cursor one left: now at index 1 (on 'b')
+	stdin.write(LEFT_ARROW);
+	await delay(100);
+
+	// Backspace removes char at index 0 ('a'), cursor moves to 0
+	stdin.write(BACKSPACE);
+	await delay(100);
+
+	const frame = lastFrame()!;
+	// Value is now "b", cursor at index 0 — rendered as inverse-'b'
+	t.true(
+		frame.includes('\u001B[7mb\u001B[27m'),
+		`Expected cursor on "[b]" but got: ${JSON.stringify(frame)}`,
+	);
+});
+
+test('backspace at start of string does nothing', async t => {
+	const {lastFrame, stdin} = render(
+		<MouseProvider>
+			<InputBox onSend={() => {}} />
+		</MouseProvider>,
+	);
+
+	// Single char so one left arrow puts cursor at index 0
+	stdin.write('a');
+	await delay(100);
+
+	stdin.write(LEFT_ARROW);
+	await delay(100);
+
+	const frameBefore = lastFrame()!;
+
+	// Cursor is at index 0 — nothing to the left
+	stdin.write(BACKSPACE);
+	await delay(100);
+
+	t.is(lastFrame(), frameBefore);
+});


### PR DESCRIPTION
## Summary

- Fixes #250 — Delete key was behaving identically to Backspace (deleting to the left and moving the cursor back)
- Split the `key.backspace || key.delete` branch in `text-input.tsx` into two separate branches:
  - **Backspace**: deletes the character to the left of the cursor, moves cursor left by 1
  - **Delete**: deletes the character at the cursor position (to the right), cursor stays in place
- Added `tests/text-input.test.tsx` with 4 integration tests covering both keys at mid-string and boundary positions

## Test plan

- [x] `delete key removes character to the right of cursor` — types "ab", moves cursor before 'b', presses Delete, verifies value is "a" with cursor at end
- [x] `delete key at end of string does nothing` — verifies Delete is a no-op at end of string
- [x] `backspace removes character to the left of cursor` — types "ab", moves cursor before 'b', presses Backspace, verifies cursor is now on 'b'
- [x] `backspace at start of string does nothing` — verifies Backspace is a no-op at position 0
- [x] Full test suite: 85/85 pass