### PR TITLE
fix: :upload and #path handle filenames with spaces

### DIFF
--- a/source/utils/chat-commands.ts
+++ b/source/utils/chat-commands.ts
@@ -140,32 +140,36 @@ export const chatCommands: Record<string, ChatCommand> = {
 		description:
 			'Upload a photo or video to the current thread. Usage: :upload <path>',
 		async handler(arguments_, {client, chatState}) {
-			let [path] = arguments_;
-			if (!path) {
+			// Join all parts so paths containing spaces work without quoting
+			let filePath = arguments_.join(' ').trim();
+			if (!filePath) {
 				return 'Usage: :upload <path-to-file>';
 			}
 
-			// Remove '#' prefix if present (from autocomplete)
-			if (path.startsWith('#')) {
-				path = path.slice(1);
+			// Strip leading '#' (inserted by autocomplete)
+			if (filePath.startsWith('#')) {
+				filePath = filePath.slice(1);
 			}
 
-			const lowerPath = path.toLowerCase();
-			const isImage = /\.(jpg|jpeg|png|gif)$/.test(lowerPath);
-			const isVideo = /\.(mp4|mov|avi|mkv)$/.test(lowerPath);
+			// Strip surrounding single or double quotes
+			filePath = filePath.replaceAll(/^["']|["']$/g, '');
 
 			if (!chatState.currentThread) {
 				return;
 			}
 
+			const lowerPath = filePath.toLowerCase();
+			const isImage = /\.(jpg|jpeg|png|gif)$/.test(lowerPath);
+			const isVideo = /\.(mp4|mov|avi|mkv)$/.test(lowerPath);
+
 			if (isImage) {
-				await client.sendPhoto(chatState.currentThread.id, path);
-				return `Image uploaded: ${path}`;
+				await client.sendPhoto(chatState.currentThread.id, filePath);
+				return `Image uploaded: ${filePath}`;
 			}
 
 			if (isVideo) {
-				await client.sendVideo(chatState.currentThread.id, path);
-				return `Video uploaded: ${path}`;
+				await client.sendVideo(chatState.currentThread.id, filePath);
+				return `Video uploaded: ${filePath}`;
 			}
 
 			return 'Unsupported file type. Please upload an image or video.';

--- a/source/utils/preprocess.ts
+++ b/source/utils/preprocess.ts
@@ -32,8 +32,10 @@ export async function preprocessMessage(
 		return getEmojiByName(emojiName) ?? `:${emojiName}:`;
 	});
 
-	// 2. File Path Handling: Find #<path> patterns with file indicators
-	const filePathRegex = /(#"([^#]*[./~][^\s#]*)")|(#([^\s#]*[./~][^\s#]*))/g;
+	// 2. File Path Handling: Find #<path> patterns with file indicators.
+	// Supports: #"path with spaces", #'path with spaces', #/unquoted/path
+	const filePathRegex =
+		/(#"([^#"]*[./~][^#"]*)")|(#'([^#']*[./~][^#']*)')|(#([^\s#]*[./~][^\s#]*))/g;
 	const matches = [...processedText.matchAll(filePathRegex)];
 
 	for (const match of matches) {

--- a/tests/chat-commands.test.ts
+++ b/tests/chat-commands.test.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import test from 'ava';
+import {
+	chatCommands,
+	type ChatCommandContext,
+} from '../source/utils/chat-commands.js';
+import {mockClient} from '../source/mocks/mock-client.js';
+import type {ChatState} from '../source/types/instagram.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockThread = {
+	id: 'thread_1',
+	title: 'Test Thread',
+	users: [],
+	lastActivity: new Date(),
+	unread: false,
+};
+
+function makeContext(overrides?: Partial<ChatState>): ChatCommandContext {
+	return {
+		client: mockClient,
+		chatState: {
+			messages: [],
+			currentThread: mockThread,
+			isSelectionMode: false,
+			selectedMessageIndex: undefined,
+			...overrides,
+		},
+		setChatState() {},
+		height: 24,
+		scrollViewRef: {current: undefined},
+	};
+}
+
+// ── :upload command ───────────────────────────────────────────────────────────
+
+const uploadHandler = chatCommands['upload']!.handler;
+
+test(':upload with plain path (no spaces) uploads image', async t => {
+	const result = await uploadHandler(['Desktop/photo.jpg'], makeContext());
+	t.is(result, 'Image uploaded: Desktop/photo.jpg');
+});
+
+test(':upload with spaced path uploads image', async t => {
+	// Simulates: ":upload Desktop/test 1.png"
+	// The command parser splits on whitespace, so arguments_ = ['Desktop/test', '1.png']
+	const result = await uploadHandler(['Desktop/test', '1.png'], makeContext());
+	t.is(result, 'Image uploaded: Desktop/test 1.png');
+});
+
+test(':upload with double-quoted path strips quotes and uploads', async t => {
+	const result = await uploadHandler(['"Desktop/my photo.jpg"'], makeContext());
+	t.is(result, 'Image uploaded: Desktop/my photo.jpg');
+});
+
+test(':upload with single-quoted path strips quotes and uploads', async t => {
+	const result = await uploadHandler(["'Desktop/my photo.jpg'"], makeContext());
+	t.is(result, 'Image uploaded: Desktop/my photo.jpg');
+});
+
+test(':upload with #-prefixed path strips hash and uploads', async t => {
+	// Autocomplete inserts a '#' prefix
+	const result = await uploadHandler(['#Desktop/photo.png'], makeContext());
+	t.is(result, 'Image uploaded: Desktop/photo.png');
+});
+
+test(':upload with video extension uploads video', async t => {
+	const result = await uploadHandler(['Desktop/clip.mp4'], makeContext());
+	t.is(result, 'Video uploaded: Desktop/clip.mp4');
+});
+
+test(':upload with unsupported extension returns error', async t => {
+	const result = await uploadHandler(['Desktop/document.pdf'], makeContext());
+	t.is(result, 'Unsupported file type. Please upload an image or video.');
+});
+
+test(':upload with no arguments returns usage hint', async t => {
+	const result = await uploadHandler([], makeContext());
+	t.is(result, 'Usage: :upload <path-to-file>');
+});
+
+test(':upload without active thread returns undefined', async t => {
+	const result = await uploadHandler(
+		['photo.jpg'],
+		makeContext({currentThread: undefined}),
+	);
+	t.is(result, undefined);
+});


### PR DESCRIPTION
## Summary

Fixes #224 — `:upload Desktop/test 1.png` returned "Unsupported file type" for any filename containing a space.

**Root cause:** The command dispatcher splits the full input on whitespace (`text.slice(1).split(/\s+/)`) before passing tokens to handlers. The `:upload` handler took only the first token (`arguments_[0]`), so `Desktop/test 1.png` became `Desktop/test` — stripping the extension and causing the type check to fail.

### Changes

**`source/utils/chat-commands.ts`**
- Join all arguments with a space before processing: `arguments_.join(' ').trim()`
- Strip surrounding single or double quotes (so both `:upload "my file.jpg"` and `:upload 'my file.jpg'` work)
- Fix variable name `path` → `filePath` (was shadowing the `node:path` import)

**`source/utils/preprocess.ts`**
- Add single-quote alternative to the inline `#<path>` regex so `#'my file.jpg'` is matched alongside the existing `#"my file.jpg"` support

**`tests/chat-commands.test.ts`** (new)
- 8 unit tests: plain path, spaced path (the exact bug), double-quoted, single-quoted, `#`-prefixed, video extension, unsupported type, empty args

## Test plan

- [x] `:upload Desktop/test 1.png` — arguments `['Desktop/test', '1.png']` → joined → `Desktop/test 1.png` → image upload succeeds
- [x] `:upload photo.jpg` — single token still works
- [x] `:upload "my photo.jpg"` / `:upload 'my photo.jpg'` — quotes stripped
- [x] `:upload #photo.png` — hash prefix stripped (autocomplete path)
- [x] `:upload clip.mp4` — video path routes to `sendVideo`
- [x] `:upload doc.pdf` — returns "Unsupported file type"
- [x] Full test suite: 90/90 pass