### PR TITLE
fix: prevent arbitrary file read and exfiltration via #path syntax

### DIFF
--- a/source/utils/chat-commands.ts
+++ b/source/utils/chat-commands.ts
@@ -6,6 +6,7 @@ import type {ScrollViewRef} from '../ui/components/scroll-view.js';
 import {ConfigManager} from '../config.js';
 import {preprocessMessage} from './preprocess.js';
 import {createContextualLogger} from './logger.js';
+import {resolveUserPath, validateFilePath} from './path-utils.js';
 import {getEmojiByName} from './emoji.js';
 
 const logger = createContextualLogger('ChatCommands');
@@ -158,17 +159,23 @@ export const chatCommands: Record<string, ChatCommand> = {
 				return;
 			}
 
+			const absolutePath = resolveUserPath(filePath);
+			const validation = await validateFilePath(absolutePath, 'media');
+			if (!validation.allowed) {
+				return `Upload blocked: ${validation.reason}`;
+			}
+
 			const lowerPath = filePath.toLowerCase();
 			const isImage = /\.(jpg|jpeg|png|gif)$/.test(lowerPath);
 			const isVideo = /\.(mp4|mov|avi|mkv)$/.test(lowerPath);
 
 			if (isImage) {
-				await client.sendPhoto(chatState.currentThread.id, filePath);
+				await client.sendPhoto(chatState.currentThread.id, absolutePath);
 				return `Image uploaded: ${filePath}`;
 			}
 
 			if (isVideo) {
-				await client.sendVideo(chatState.currentThread.id, filePath);
+				await client.sendVideo(chatState.currentThread.id, absolutePath);
 				return `Video uploaded: ${filePath}`;
 			}
 

--- a/source/utils/path-utils.ts
+++ b/source/utils/path-utils.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import {cwd} from 'node:process';
@@ -32,4 +33,103 @@ export function resolveUserPath(
 	}
 
 	return path.resolve(cwdPath, expandedPath);
+}
+
+/** Maximum file size (in bytes) for text embedding via #path syntax. */
+const maxTextEmbedBytes = 50 * 1024; // 50 KB
+
+/** Maximum file size (in bytes) for media uploads via :upload. */
+const maxMediaUploadBytes = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Path segments and filenames that indicate sensitive files which should
+ * never be read or transmitted over the network.
+ */
+const sensitivePatterns: readonly RegExp[] = [
+	/(?:^|\/)\.ssh\//,
+	/(?:^|\/)\.gnupg\//,
+	/(?:^|\/)\.aws\//,
+	/(?:^|\/)\.docker\/config\.json$/,
+	/(?:^|\/)\.kube\//,
+	/(?:^|\/)\.npmrc$/,
+	/(?:^|\/)\.netrc$/,
+	/(?:^|\/)\.env(?:\.|$)/,
+	/(?:^|\/)\.git\/config$/,
+	/(?:^|\/)\.gitconfig$/,
+	/(?:^|\/)session\.ts\.json$/,
+	/(?:^|\/)credentials(?:\.json)?$/,
+	/(?:^|\/)id_(?:rsa|ed25519|ecdsa|dsa)(?:\.pub)?$/,
+	/(?:^|\/)known_hosts$/,
+	/(?:^|\/)authorized_keys$/,
+	/(?:^|\/)\.password/,
+	/(?:^|\/)\.token/,
+];
+
+export type FileValidationResult = {
+	readonly allowed: boolean;
+	readonly reason?: string;
+	readonly sizeBytes?: number;
+};
+
+/**
+ * Validates whether a resolved absolute path is safe to read and transmit.
+ *
+ * Checks performed:
+ * 1. Path must be inside the user's home directory (blocks /etc/passwd etc.)
+ * 2. Path must not match known sensitive file patterns
+ * 3. File size must be within the limit for its intended use
+ *
+ * @param absolutePath - The fully resolved path to validate.
+ * @param mode - 'text' for #path embedding (50 KB cap), 'media' for :upload (50 MB cap).
+ * @returns Validation result with allowed flag and reason if blocked.
+ */
+export async function validateFilePath(
+	absolutePath: string,
+	mode: 'text' | 'media' = 'text',
+): Promise<FileValidationResult> {
+	const normalized = path.normalize(absolutePath);
+	const home = os.homedir();
+
+	// 1. Must be inside the user's home directory
+	if (!normalized.startsWith(home + path.sep) && normalized !== home) {
+		return {
+			allowed: false,
+			reason: `Blocked: path is outside your home directory`,
+		};
+	}
+
+	// 2. Must not match sensitive file patterns
+	for (const pattern of sensitivePatterns) {
+		if (pattern.test(normalized)) {
+			return {
+				allowed: false,
+				reason: `Blocked: path matches a sensitive file pattern`,
+			};
+		}
+	}
+
+	// 3. File size must be within the limit
+	const maxBytes = mode === 'text' ? maxTextEmbedBytes : maxMediaUploadBytes;
+	let stat;
+	try {
+		stat = await fs.stat(normalized);
+	} catch {
+		return {allowed: false, reason: `File not found or not accessible`};
+	}
+
+	if (stat.size > maxBytes) {
+		const limitMb = mode === 'text' ? '50 KB' : '50 MB';
+		return {
+			allowed: false,
+			reason: `File is too large (${formatBytes(stat.size)}, limit: ${limitMb})`,
+		};
+	}
+
+	return {allowed: true, sizeBytes: stat.size};
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/source/utils/preprocess.ts
+++ b/source/utils/preprocess.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import {fileTypeFromFile} from 'file-type';
 import type {InstagramClient} from '../client.js';
-import {resolveUserPath} from './path-utils.js';
+import {resolveUserPath, validateFilePath} from './path-utils.js';
 import {getEmojiByName} from './emoji.js';
 import {createContextualLogger} from './logger.js';
 
@@ -53,6 +53,15 @@ export async function preprocessMessage(
 		try {
 			// eslint-disable-next-line no-await-in-loop
 			const fileType = await fileTypeFromFile(absolutePath);
+			const mode = fileType?.mime.startsWith('image/') ? 'media' : 'text';
+
+			// eslint-disable-next-line no-await-in-loop
+			const validation = await validateFilePath(absolutePath, mode);
+			if (!validation.allowed) {
+				logger.warn(`File blocked: ${absolutePath} — ${validation.reason}`);
+				continue;
+			}
+
 			logger.debug(
 				`Processing file: ${absolutePath}, type: ${fileType?.mime ?? 'text'}`,
 			);

--- a/tests/chat-commands.test.ts
+++ b/tests/chat-commands.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'ava';
 import {
 	chatCommands,
@@ -8,6 +11,28 @@ import {
 } from '../source/utils/chat-commands.js';
 import {mockClient} from '../source/mocks/mock-client.js';
 import type {ChatState} from '../source/types/instagram.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+let tempDir: string;
+let imgPath: string;
+let vidPath: string;
+let pdfPath: string;
+
+test.before(() => {
+	tempDir = fs.mkdtempSync(path.join(os.homedir(), '.instagram-cli-test-'));
+	imgPath = path.join(tempDir, 'photo.jpg');
+	vidPath = path.join(tempDir, 'clip.mp4');
+	pdfPath = path.join(tempDir, 'document.pdf');
+
+	fs.writeFileSync(imgPath, 'fake-image');
+	fs.writeFileSync(vidPath, 'fake-video');
+	fs.writeFileSync(pdfPath, 'fake-pdf');
+});
+
+test.after.always(() => {
+	fs.rmSync(tempDir, {recursive: true, force: true});
+});
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -40,40 +65,43 @@ function makeContext(overrides?: Partial<ChatState>): ChatCommandContext {
 const uploadHandler = chatCommands['upload']!.handler;
 
 test(':upload with plain path (no spaces) uploads image', async t => {
-	const result = await uploadHandler(['Desktop/photo.jpg'], makeContext());
-	t.is(result, 'Image uploaded: Desktop/photo.jpg');
+	const result = await uploadHandler([imgPath], makeContext());
+	t.is(result, `Image uploaded: ${imgPath}`);
 });
 
 test(':upload with spaced path uploads image', async t => {
-	// Simulates: ":upload Desktop/test 1.png"
-	// The command parser splits on whitespace, so arguments_ = ['Desktop/test', '1.png']
-	const result = await uploadHandler(['Desktop/test', '1.png'], makeContext());
-	t.is(result, 'Image uploaded: Desktop/test 1.png');
+	const spacedDir = path.join(tempDir, 'sub dir');
+	fs.mkdirSync(spacedDir, {recursive: true});
+	const spacedImg = path.join(spacedDir, 'pic.jpg');
+	fs.writeFileSync(spacedImg, 'fake');
+	// The command parser splits on whitespace, so arguments_ has multiple parts
+	const parts = spacedImg.split(' ');
+	const result = await uploadHandler(parts, makeContext());
+	t.is(result, `Image uploaded: ${spacedImg}`);
 });
 
 test(':upload with double-quoted path strips quotes and uploads', async t => {
-	const result = await uploadHandler(['"Desktop/my photo.jpg"'], makeContext());
-	t.is(result, 'Image uploaded: Desktop/my photo.jpg');
+	const result = await uploadHandler([`"${imgPath}"`], makeContext());
+	t.is(result, `Image uploaded: ${imgPath}`);
 });
 
 test(':upload with single-quoted path strips quotes and uploads', async t => {
-	const result = await uploadHandler(["'Desktop/my photo.jpg'"], makeContext());
-	t.is(result, 'Image uploaded: Desktop/my photo.jpg');
+	const result = await uploadHandler([`'${imgPath}'`], makeContext());
+	t.is(result, `Image uploaded: ${imgPath}`);
 });
 
 test(':upload with #-prefixed path strips hash and uploads', async t => {
-	// Autocomplete inserts a '#' prefix
-	const result = await uploadHandler(['#Desktop/photo.png'], makeContext());
-	t.is(result, 'Image uploaded: Desktop/photo.png');
+	const result = await uploadHandler([`#${imgPath}`], makeContext());
+	t.is(result, `Image uploaded: ${imgPath}`);
 });
 
 test(':upload with video extension uploads video', async t => {
-	const result = await uploadHandler(['Desktop/clip.mp4'], makeContext());
-	t.is(result, 'Video uploaded: Desktop/clip.mp4');
+	const result = await uploadHandler([vidPath], makeContext());
+	t.is(result, `Video uploaded: ${vidPath}`);
 });
 
 test(':upload with unsupported extension returns error', async t => {
-	const result = await uploadHandler(['Desktop/document.pdf'], makeContext());
+	const result = await uploadHandler([pdfPath], makeContext());
 	t.is(result, 'Unsupported file type. Please upload an image or video.');
 });
 
@@ -84,8 +112,21 @@ test(':upload with no arguments returns usage hint', async t => {
 
 test(':upload without active thread returns undefined', async t => {
 	const result = await uploadHandler(
-		['photo.jpg'],
+		[imgPath],
 		makeContext({currentThread: undefined}),
 	);
 	t.is(result, undefined);
+});
+
+// ── Security: :upload blocks dangerous paths ────────────────────────────────
+
+test(':upload blocks paths outside home directory', async t => {
+	const result = await uploadHandler(['/etc/passwd'], makeContext());
+	t.truthy(typeof result === 'string' && result.startsWith('Upload blocked'));
+});
+
+test(':upload blocks sensitive paths', async t => {
+	const sshKey = path.join(os.homedir(), '.ssh/id_rsa');
+	const result = await uploadHandler([sshKey], makeContext());
+	t.truthy(typeof result === 'string' && result.startsWith('Upload blocked'));
 });

--- a/tests/path-security.test.ts
+++ b/tests/path-security.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+
+import {Buffer} from 'node:buffer';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'ava';
+import {validateFilePath} from '../source/utils/path-utils.js';
+
+// Create temp files inside the home directory for size tests
+let tempDir: string;
+let smallFile: string;
+let largeFile: string;
+
+test.before(async () => {
+	tempDir = await fs.mkdtemp(path.join(os.homedir(), '.instagram-cli-test-'));
+	smallFile = path.join(tempDir, 'small.txt');
+	largeFile = path.join(tempDir, 'large.txt');
+
+	await fs.writeFile(smallFile, 'hello');
+	// 60 KB — over the 50 KB text limit
+	await fs.writeFile(largeFile, Buffer.alloc(60 * 1024, 'x'));
+});
+
+test.after.always(async () => {
+	await fs.rm(tempDir, {recursive: true, force: true});
+});
+
+// --- Home directory boundary ---
+
+test.serial('blocks paths outside home directory', async t => {
+	const result = await validateFilePath('/etc/passwd');
+	t.false(result.allowed);
+	t.truthy(result.reason?.includes('outside'));
+});
+
+test.serial('blocks /etc/shadow', async t => {
+	const result = await validateFilePath('/etc/shadow');
+	t.false(result.allowed);
+});
+
+test.serial('allows paths inside home directory', async t => {
+	const result = await validateFilePath(smallFile);
+	t.true(result.allowed);
+	t.is(result.sizeBytes, 5);
+});
+
+// --- Sensitive file patterns ---
+
+test.serial('blocks .ssh paths', async t => {
+	const sshKey = path.join(os.homedir(), '.ssh', 'id_rsa');
+	const result = await validateFilePath(sshKey);
+	t.false(result.allowed);
+	t.truthy(result.reason?.includes('sensitive'));
+});
+
+test.serial('blocks .env files', async t => {
+	const envFile = path.join(os.homedir(), 'project', '.env');
+	const result = await validateFilePath(envFile);
+	t.false(result.allowed);
+	t.truthy(result.reason?.includes('sensitive'));
+});
+
+test.serial('blocks .aws credentials', async t => {
+	const awsCreds = path.join(os.homedir(), '.aws', 'credentials');
+	const result = await validateFilePath(awsCreds);
+	t.false(result.allowed);
+});
+
+test.serial('blocks session.ts.json', async t => {
+	const session = path.join(
+		os.homedir(),
+		'.instagram-cli',
+		'users',
+		'test',
+		'session.ts.json',
+	);
+	const result = await validateFilePath(session);
+	t.false(result.allowed);
+});
+
+// --- File size limits ---
+
+test.serial('allows small text files', async t => {
+	const result = await validateFilePath(smallFile, 'text');
+	t.true(result.allowed);
+});
+
+test.serial('blocks text files over 50 KB', async t => {
+	const result = await validateFilePath(largeFile, 'text');
+	t.false(result.allowed);
+	t.truthy(result.reason?.includes('too large'));
+});
+
+test.serial('allows large files in media mode (under 50 MB)', async t => {
+	const result = await validateFilePath(largeFile, 'media');
+	t.true(result.allowed);
+});
+
+// --- Edge cases ---
+
+test.serial('returns not-found for nonexistent files', async t => {
+	const result = await validateFilePath(
+		path.join(os.homedir(), 'nonexistent-file-abc123.txt'),
+	);
+	t.false(result.allowed);
+	t.truthy(result.reason?.includes('not found'));
+});


### PR DESCRIPTION
Closes #274

## Summary

- Adds `validateFilePath()` in `path-utils.ts` with three layers of defense:
  - **Home directory boundary** — blocks any path outside `~/` (prevents `/etc/passwd`, `/etc/shadow`)
  - **Sensitive path denylist** — blocks `.ssh/`, `.aws/`, `.env`, `.gnupg/`, `session.ts.json`, credential files, etc.
  - **File size cap** — 50 KB for text embedding (`#path`), 50 MB for media uploads (`:upload`)
- Wired into `preprocess.ts` (the `#path` message syntax) and `chat-commands.ts` (the `:upload` command)
- Blocked files are logged and silently skipped in message preprocessing, or return a user-visible `Upload blocked: <reason>` in `:upload`

## Changes

| File | Change |
|---|---|
| `source/utils/path-utils.ts` | Add `validateFilePath()`, sensitive patterns, size limits |
| `source/utils/preprocess.ts` | Call validation before reading/sending files |
| `source/utils/chat-commands.ts` | Call validation before uploads, resolve paths properly |
| `tests/path-security.test.ts` | 11 new tests for home boundary, denylist, size limits, edge cases |
| `tests/chat-commands.test.ts` | Updated upload tests to use real temp files (required by validation) |

## Test plan

- [x] 116 tests pass (105 existing + 11 new)
- [x] npm run format — clean
- [x] npm run lint-check — clean (no new warnings)
- [x] Verified: #~/.ssh/id_rsa is blocked (home dir + sensitive pattern)
- [x] Verified: #/etc/passwd is blocked (outside home)
- [x] Verified: normal file embedding still works
- [ ] Manual test: try #path in a real DM session to confirm UX

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>