### PR TITLE
fix: show helpful error for unknown commands

### DIFF
--- a/source/commands/index.tsx
+++ b/source/commands/index.tsx
@@ -2,8 +2,26 @@ import React from 'react';
 import Gradient from 'ink-gradient';
 import BigText from 'ink-big-text';
 import {Text} from 'ink';
+import zod from 'zod';
 
-export default function Index() {
+export const args = zod.tuple([]).rest(zod.string());
+
+type Props = {
+	readonly args?: string[];
+};
+
+const defaultArgs: string[] = [];
+
+export default function Index({args: unknownArgs = defaultArgs}: Props) {
+	if (unknownArgs.length > 0) {
+		return (
+			<>
+				<Text color="red">Unknown command: {unknownArgs.join(' ')}</Text>
+				<Text>Run &#39;instagram-cli --help&#39; for available commands.</Text>
+			</>
+		);
+	}
+
 	return (
 		<>
 			<Gradient

--- a/tests/e2e.test.tsx
+++ b/tests/e2e.test.tsx
@@ -20,6 +20,14 @@ test('sanity check', (t: ExecutionContext) => {
 	t.not(lastFrame(), undefined);
 });
 
+test('unknown command shows helpful error', (t: ExecutionContext) => {
+	const {lastFrame} = render(<Index args={['asdfljk']} />);
+	const output = lastFrame()!;
+	t.true(output.includes('Unknown command'));
+	t.true(output.includes('asdfljk'));
+	t.true(output.includes('--help'));
+});
+
 test('renders chat view', (t: ExecutionContext) => {
 	const {lastFrame} = render(<AppMock view="chat" />);
 


### PR DESCRIPTION
Closes #222

## Summary

- `instagram-cli asdfljk` now shows `Unknown command: asdfljk` + `--help` pointer instead of the confusing `too many arguments. Expected 0 but got 1`
- The index command accepts rest args via `zod.tuple([]).rest(zod.string())` and renders an error when any are provided
- Existing welcome banner is unchanged when no args are passed

## Changes

| File | Change |
|---|---|
| `source/commands/index.tsx` | Accept rest args, show error for unknown commands |
| `tests/e2e.test.tsx` | Add test for unknown command error rendering |

## Test plan

- [x] 104 tests pass
- [x] `npm run format` — clean
- [x] `npm run lint-check` — clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>