### PR TITLE
refactor: list detail cleanup

### DIFF
--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -50,6 +50,10 @@ function getBestImage(
 	return bestCandidate.url;
 }
 
+function getPostMetadata(metadata: unknown): PostMetadata {
+	return metadata as PostMetadata;
+}
+
 const logger = createContextualLogger('ListDetailDisplay');
 
 export default function ListDetailDisplay<
@@ -334,8 +338,9 @@ export default function ListDetailDisplay<
 							{mode === 'post' &&
 								currentItem?.additional_metadata &&
 								(() => {
-									const metadata =
-										currentItem.additional_metadata as unknown as PostMetadata;
+									const metadata = getPostMetadata(
+										currentItem.additional_metadata,
+									);
 									return (
 										<>
 											{currentItem.additional_metadata && metadata.caption && (

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -23,6 +23,9 @@ type Properties<T extends BaseMedia & MediaItemMetadata, M = undefined> = {
 	readonly protocol?: ImageProtocolName;
 	readonly client?: InstagramClient | undefined;
 	readonly mode: 'story' | 'post';
+	readonly handleSearchSubmit?: (
+		query: string,
+	) => Promise<ListMediaItem<T, M> | undefined>;
 };
 
 function getBestImage(
@@ -65,6 +68,7 @@ export default function ListDetailDisplay<
 	protocol,
 	client,
 	mode,
+	handleSearchSubmit,
 }: Properties<T, M>) {
 	const [selectedIndex, setSelectedIndex] = useState<number>(0);
 	const [carouselIndex, setCarouselIndex] = useState<number>(0);
@@ -147,38 +151,35 @@ export default function ListDetailDisplay<
 		}
 	};
 
-	const handleSearchSubmit = async () => {
+	const handleSearch = () => {
+		if (!handleSearchSubmit) {
+			return;
+		}
+
 		if (!client || !searchQuery.trim()) {
 			setSearchError('Search query cannot be empty.');
 			return;
 		}
 
 		setSearchError(undefined);
-		try {
-			const stories = await client.getStoriesForUser(
-				undefined,
-				searchQuery.trim(),
-			);
-			if (stories.length > 0 && stories[0]?.user) {
-				const newItem: ListMediaItem<T, M> = {
-					pk: stories[0].user.pk,
-					label: stories[0].user.username,
-					content: stories as unknown as T[],
-				};
-				setCombinedItems(prev => [newItem, ...prev]);
-				setSelectedIndex(0);
-			} else {
-				setSearchError(`No stories found for user "${searchQuery.trim()}".`);
-			}
+		void handleSearchSubmit(searchQuery.trim())
+			.then(result => {
+				if (result) {
+					setCombinedItems(prev => [result, ...prev]);
+					setSelectedIndex(0);
+				} else {
+					setSearchError(`No stories found for user "${searchQuery.trim()}".`);
+				}
 
-			setSearchQuery('');
-			setIsSearchMode(false);
-		} catch (error: unknown) {
-			const errorMessage =
-				error instanceof Error ? error.message : String(error);
-			logger.error(`Search failed: ${errorMessage}`);
-			setSearchError(`Search failed: ${errorMessage}`);
-		}
+				setSearchQuery('');
+				setIsSearchMode(false);
+			})
+			.catch((error: unknown) => {
+				const errorMessage =
+					error instanceof Error ? error.message : String(error);
+				logger.error(`Search failed: ${errorMessage}`);
+				setSearchError(`Search failed: ${errorMessage}`);
+			});
 	};
 
 	useInput((input, key) => {
@@ -188,7 +189,7 @@ export default function ListDetailDisplay<
 				setSearchQuery('');
 				setSearchError(undefined);
 			} else if (key.return) {
-				void handleSearchSubmit();
+				handleSearch();
 			}
 			// Input component handles other keys when focused
 		} else if (input === 's' && mode === 'story') {

--- a/source/ui/views/story-view.tsx
+++ b/source/ui/views/story-view.tsx
@@ -16,6 +16,22 @@ export default function StoryView({
 }) {
 	const imageProtocol = useImageProtocol();
 
+	const handleSearchSubmit = async (
+		query: string,
+	): Promise<ListMediaItem<Story> | undefined> => {
+		const stories = await client!.getStoriesForUser(undefined, query);
+		if (stories.length > 0 && stories[0]?.user) {
+			const result: ListMediaItem<Story> = {
+				pk: stories[0].user.pk,
+				label: stories[0].user.username,
+				content: stories,
+			};
+			return result;
+		}
+
+		return undefined;
+	};
+
 	return (
 		<TerminalInfoProvider>
 			<ListDetailDisplay
@@ -24,6 +40,7 @@ export default function StoryView({
 				protocol={imageProtocol}
 				client={client}
 				mode="story"
+				handleSearchSubmit={handleSearchSubmit}
 			/>
 		</TerminalInfoProvider>
 	);


### PR DESCRIPTION
Small addition to #339 

## Summary

Two small cleanups in ListDetailDisplay:                                                                                                                                                                                                                                                                                                                                 
- Moved `handleSearchSubmit` to the parent `StoryView` and extracted the inline useInput handler into a named function. (This may be also suitable if a search function is implemented for feed too)                                                                       
- Replaced the `as unknown as PostMetadata` cast with a `getPostMetadata` helper.      

I did those mainly to avoid having those `as unknown as ...`   casts.                                          

## Testing

- [x] `npm run build`
- [x] `npm run lint-check` (0 errors)
- [x] `npm test` (115 tests passed)
- [x] Live run testing