### PR TITLE
Feature: scrolleable usernames list

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -995,7 +995,7 @@ export class InstagramClient extends EventEmitter {
 						item.user !== undefined,
 				)
 				.map(item => ({
-					pk: item.user.pk,
+					pk: String(item.user.pk),
 					label: item.user.username ?? `User_${item.user.pk}`,
 					content: [], // Stories will be lazy-loaded
 				}));

--- a/source/mocks/mock-client.ts
+++ b/source/mocks/mock-client.ts
@@ -474,7 +474,7 @@ class MockClient extends EventEmitter {
 		}
 
 		return [...usersWithStories.values()].map(user => ({
-			pk: typeof user.pk === 'string' ? Number(user.pk) : user.pk,
+			pk: typeof user.pk === 'string' ? user.pk : String(user.pk),
 			label: user.username,
 			content: [],
 		}));

--- a/source/mocks/mock-data.ts
+++ b/source/mocks/mock-data.ts
@@ -7,111 +7,316 @@ import type {
 	Story,
 } from '../types/instagram.js';
 
-// Mock users
+export const MOCK_USER_COUNT = 75;
+
+const firstNames = [
+	'Alice',
+	'Bob',
+	'Charlie',
+	'Diana',
+	'Eva',
+	'Frank',
+	'Grace',
+	'Henry',
+	'Isabella',
+	'Jack',
+	'Katie',
+	'Liam',
+	'Mia',
+	'Noah',
+	'Olivia',
+	'Peter',
+	'Quinn',
+	'Rachel',
+	'Sam',
+	'Tina',
+	'Uma',
+	'Victor',
+	'Wendy',
+	'Xander',
+	'Yara',
+	'Zack',
+	'Aria',
+	'Ben',
+	'Clara',
+	'David',
+	'Ella',
+	'Finn',
+	'Gemma',
+	'Hugo',
+	'Ivy',
+	'Jake',
+	'Kira',
+	'Leo',
+	'Nora',
+	'Oscar',
+	'Paige',
+	'Riley',
+	'Sage',
+	'Theo',
+	'Violet',
+	'Wade',
+	'Zoe',
+	'Adam',
+	'Bella',
+	'Carter',
+	'Daisy',
+	'Ethan',
+	'Faith',
+	'Gavin',
+	'Hannah',
+	'Ian',
+	'Jade',
+	'Kai',
+	'Luna',
+	'Miles',
+	'Natalie',
+	'Owen',
+	'Phoebe',
+	'Quincy',
+	'Rose',
+	'Silas',
+	'Tessa',
+	'Uri',
+	'Vera',
+	'Wyatt',
+	'Xena',
+	'Yves',
+	'Zara',
+	'Aiden',
+	'Brooke',
+];
+
+const lastNames = [
+	'Smith',
+	'Johnson',
+	'Brown',
+	'Prince',
+	'Martinez',
+	'Lee',
+	'Kim',
+	'Chen',
+	'Torres',
+	'Wilson',
+	'Nguyen',
+	'Patel',
+	'Anderson',
+	'Thomas',
+	'White',
+	'Jackson',
+	'Harris',
+	'Garcia',
+	'Clark',
+	'Robinson',
+	'Lewis',
+	'Walker',
+	'Hall',
+	'Allen',
+	'Scott',
+	'Taylor',
+	'Moore',
+	'Davis',
+	'Miller',
+	'Wilson',
+	'Young',
+	'King',
+	'Wright',
+	'Hill',
+	'Green',
+	'Adams',
+	'Baker',
+	'Nelson',
+	'Carter',
+	'Mitchell',
+	'Roberts',
+	'Turner',
+	'Phillips',
+	'Campbell',
+	'Parker',
+	'Evans',
+	'Edwards',
+	'Collins',
+	'Stewart',
+	'Morris',
+	'Murphy',
+	'Cook',
+	'Rogers',
+	'Morgan',
+	'Peterson',
+	'Cooper',
+	'Reed',
+	'Bailey',
+	'Bell',
+	'Howard',
+	'Ward',
+	'Brooks',
+	'Kelly',
+	'Sanders',
+	'Price',
+	'Bennett',
+	'Wood',
+	'Barnes',
+	'Ross',
+	'Henderson',
+	'Coleman',
+	'Jenkins',
+	'Perry',
+	'Powell',
+	'Long',
+];
+
+const imageUrls = [
+	'https://sipi.usc.edu/database/preview/misc/4.1.01.png',
+	'https://www.math.hkust.edu.hk/~masyleung/Teaching/CAS/MATLAB/image/images/cameraman.jpg',
+	'https://upload.wikimedia.org/wikipedia/en/thumb/7/7d/Lenna_%28test_image%29.png/500px-Lenna_%28test_image%29.png',
+	'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png',
+];
+
+const captions = [
+	'Beautiful sunset today! 🌅 #nature #photography',
+	'Working on some code today 💻 #coding #typescript',
+	'Great coffee this morning ☕',
+	'Morning yoga session 🧘‍♀️ #wellness #mindfulness',
+	'New recipe alert! Homemade pasta 🍝 #cooking #foodie',
+	'Hiked 12 miles today! 🏔️ #adventure #hiking',
+	'Just launched my new project! 🚀 #startup #tech',
+	'Weekend barbecue with the fam 🥩🔥 #family #weekend',
+	'Art exhibition opening night! 🎨 #art #culture',
+	'Fresh catch of the day 🎣 #fishing #outdoors',
+	'Book club meeting was amazing! 📚 #reading #books',
+	'Guitar practice paying off 🎸 #music #guitar',
+	'Adopted a new puppy! Meet Max 🐶 #dogsofinstagram #puppy',
+	'Sunrise surf session 🌊🏄 #surfing #ocean',
+	'Baking sourdough from scratch 🥖 #baking #homemade',
+	'Film set behind the scenes 🎬 #filmmaking #director',
+	'Farmers market finds! 🥕🌽 #organic #localfood',
+	'Finished my first marathon! 🏃‍♀️🎉 #marathon #fitness',
+	'Stargazing night ✨🌌 #astronomy #night',
+	'Jazz night at the Blue Note 🎷🎵 #jazz #music',
+	'Pottery class creations 🏺 #art #ceramics',
+	'Road trip across the country 🚗🛣️ #roadtrip #travel',
+	'Community garden volunteer day 🌻 #community #gardening',
+	'Chess tournament champion! ♟️🏆 #chess #strategy',
+	'sunset from the rooftop 🌇 #cityviews #sunset',
+	'Beach day with friends 🏖️ #summer #fun',
+	'New painting finished! 🖼️ #art #painting',
+	'Gardening update - look at these tomatoes! 🍅 #garden',
+	'Live concert tonight! 🎤 #concert #music',
+	'Snowy mountain views 🏔️❄️ #winter #travel',
+];
+
+const storyWidth = 1080;
+const storyHeight = 1920;
+
+function buildUser(index: number): User {
+	const first = firstNames[index]!;
+	const last = lastNames[index]!;
+	return {
+		pk: `user${index + 1}`,
+		username: `${first.toLowerCase()}_${last.toLowerCase()}`,
+		fullName: `${first} ${last}`,
+		isVerified: index % 5 === 1,
+	};
+}
+
+function buildPost(index: number): Post {
+	const first = firstNames[index]!;
+	const last = lastNames[index]!;
+	const username = `${first.toLowerCase()}_${last.toLowerCase()}`;
+	const userPk = 1001 + index;
+	const imgUrl = imageUrls[index % imageUrls.length]!;
+	const hoursAgo = (index + 1) * 2;
+
+	const mockPost: Post = {
+		id: `post${index + 1}`,
+		user: {
+			pk: userPk,
+			username,
+			profilePicUrl: index % 3 === 0 ? undefined : imgUrl,
+		},
+		caption: {text: captions[index % captions.length]!},
+		image_versions2: {
+			candidates: [{url: imgUrl, width: storyWidth, height: storyHeight}],
+		},
+		like_count: 50 + Math.floor(Math.random() * 900),
+		comment_count: 3 + Math.floor(Math.random() * 60),
+		taken_at: Date.now() - 60_000 * 60 * hoursAgo,
+		media_type: 1,
+	};
+	return mockPost;
+}
+
+function buildStory(index: number): Story[] {
+	const first = firstNames[index]!;
+	const last = lastNames[index]!;
+	const username = `${first.toLowerCase()}_${last.toLowerCase()}`;
+	const userPk = 1001 + index;
+	const imgUrl = imageUrls[index % imageUrls.length]!;
+
+	const stories: Story[] = [
+		{
+			id: `story${index + 1}`,
+			user: {pk: userPk, username, profilePicUrl: imgUrl},
+			image_versions2: {
+				candidates: [{url: imgUrl, width: storyWidth, height: storyHeight}],
+			},
+			taken_at: Date.now(),
+			media_type: 1,
+		},
+	];
+
+	if (index % 3 === 0) {
+		stories.push({
+			id: `story${index + 1}b`,
+			user: {pk: userPk, username, profilePicUrl: imgUrl},
+			image_versions2: {
+				candidates: [{url: imgUrl, width: storyWidth, height: storyHeight}],
+			},
+			taken_at: Date.now(),
+			media_type: 1,
+		});
+	}
+
+	if (index % 5 === 0 && index + 1 < firstNames.length) {
+		const mentionIdx = (index + 3) % firstNames.length;
+		const mFirst = firstNames[mentionIdx]!;
+		const mLast = lastNames[mentionIdx]!;
+		const mentionImg = imageUrls[mentionIdx % imageUrls.length]!;
+
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		stories[0]!.reel_mentions = [
+			{
+				user: {
+					username: `${mFirst.toLowerCase()}_${mLast.toLowerCase()}`,
+					pk: 1001 + mentionIdx,
+					full_name: `${mFirst} ${mLast}`,
+					profile_pic_url: mentionImg,
+				},
+			},
+		];
+	}
+
+	return stories;
+}
+
+// Hardcoded first 4 — referenced by mockThreads / mockMessages below
 export const mockUsers: User[] = [
-	{
-		pk: 'user1',
-		username: 'alice_smith',
-		fullName: 'Alice Smith',
-		isVerified: false,
-	},
-	{
-		pk: 'user2',
-		username: 'bob_johnson',
-		fullName: 'Bob Johnson',
-		isVerified: true,
-	},
-	{
-		pk: 'user3',
-		username: 'charlie_brown',
-		fullName: 'Charlie Brown',
-		isVerified: false,
-	},
-	{
-		pk: 'user4',
-		username: 'diana_prince',
-		fullName: 'Diana Prince',
-		isVerified: true,
-	},
+	buildUser(0),
+	buildUser(1),
+	buildUser(2),
+	buildUser(3),
 ];
 
-// Mock posts for feed
-export const mockPosts: Post[] = [
-	{
-		id: 'post1',
-		user: {
-			pk: 1001,
-			username: 'alice_smith',
-			profilePicUrl: 'https://sipi.usc.edu/database/preview/misc/4.1.01.png',
-		},
-		caption: {
-			text: 'Beautiful sunset today! 🌅 #nature #photography',
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: 'https://sipi.usc.edu/database/preview/misc/4.1.01.png',
-					width: 1080,
-					height: 1080,
-				},
-			],
-		},
-		like_count: 245,
-		comment_count: 12,
-		taken_at: Date.now() - 60_000 * 60 * 2, // 2 hours ago
-		media_type: 1, // Image
-	},
-	{
-		id: 'post2',
-		user: {
-			pk: 1002,
-			username: 'bob_johnson',
-			profilePicUrl:
-				'https://www.math.hkust.edu.hk/~masyleung/Teaching/CAS/MATLAB/image/images/cameraman.jpg',
-		},
-		caption: {
-			text: 'Working on some code today 💻 #coding #typescript',
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: 'https://www.math.hkust.edu.hk/~masyleung/Teaching/CAS/MATLAB/image/images/cameraman.jpg',
-					width: 512,
-					height: 512,
-				},
-			],
-		},
-		like_count: 89,
-		comment_count: 5,
-		taken_at: Date.now() - 60_000 * 60 * 4, // 4 hours ago
-		media_type: 1, // Image
-	},
-	{
-		id: 'post3',
-		user: {
-			pk: 1003,
-			username: 'charlie_brown',
-		},
-		caption: {
-			text: 'Great coffee this morning ☕',
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: 'https://upload.wikimedia.org/wikipedia/en/thumb/7/7d/Lenna_%28test_image%29.png/500px-Lenna_%28test_image%29.png',
-					width: 500,
-					height: 500,
-				},
-			],
-		},
-		like_count: 156,
-		comment_count: 8,
-		taken_at: Date.now() - 60_000 * 60 * 6, // 6 hours ago
-		media_type: 1, // Image
-	},
-];
+for (let i = 4; i < MOCK_USER_COUNT; i++) {
+	mockUsers.push(buildUser(i));
+}
 
-// Mock feed instance
+export const mockPosts: Post[] = [];
+
+for (let i = 0; i < MOCK_USER_COUNT; i++) {
+	mockPosts.push(buildPost(i));
+}
+
 export const mockFeed = {
 	posts: mockPosts,
 };
@@ -120,7 +325,7 @@ export const mockFeed = {
 export const mockMessages: Message[] = [
 	{
 		id: 'msg1',
-		timestamp: new Date(Date.now() - 60_000 * 5), // 5 minutes ago
+		timestamp: new Date(Date.now() - 60_000 * 5),
 		userId: 'user1',
 		username: 'alice_smith',
 		isOutgoing: true,
@@ -141,7 +346,7 @@ export const mockMessages: Message[] = [
 	},
 	{
 		id: 'msg2',
-		timestamp: new Date(Date.now() - 60_000 * 10), // 10 minutes ago
+		timestamp: new Date(Date.now() - 60_000 * 10),
 		userId: 'user2',
 		username: 'bob_johnson',
 		isOutgoing: false,
@@ -152,7 +357,7 @@ export const mockMessages: Message[] = [
 	},
 	{
 		id: 'msg3',
-		timestamp: new Date(Date.now() - 60_000 * 15), // 15 minutes ago
+		timestamp: new Date(Date.now() - 60_000 * 15),
 		userId: 'user1',
 		username: 'alice_smith',
 		isOutgoing: true,
@@ -181,7 +386,7 @@ export const mockMessages: Message[] = [
 	},
 	{
 		id: 'msg4',
-		timestamp: new Date(Date.now() - 60_000 * 20), // 20 minutes ago
+		timestamp: new Date(Date.now() - 60_000 * 20),
 		userId: 'user2',
 		username: 'bob_johnson',
 		isOutgoing: false,
@@ -209,7 +414,7 @@ export const mockMessages: Message[] = [
 	},
 	{
 		id: 'msg5',
-		timestamp: new Date(Date.now() - 60_000 * 25), // 25 minutes ago
+		timestamp: new Date(Date.now() - 60_000 * 25),
 		userId: 'user1',
 		username: 'alice_smith',
 		isOutgoing: true,
@@ -230,11 +435,10 @@ export const mockMessages: Message[] = [
 			original_width: 500,
 			original_height: 500,
 		},
-		// No reactions for this message
 	},
 	{
 		id: 'msg8',
-		timestamp: new Date(Date.now() - 60_000 * 3), // 3 minutes ago
+		timestamp: new Date(Date.now() - 60_000 * 3),
 		userId: 'user2',
 		username: 'bob_johnson',
 		isOutgoing: false,
@@ -247,7 +451,7 @@ export const mockMessages: Message[] = [
 	},
 	{
 		id: 'msg9',
-		timestamp: new Date(Date.now() - 60_000 * 2), // 2 minutes ago
+		timestamp: new Date(Date.now() - 60_000 * 2),
 		userId: 'user2',
 		username: 'bob_johnson',
 		isOutgoing: false,
@@ -274,13 +478,13 @@ export const mockMessages: Message[] = [
 			},
 			like_count: 15_234,
 			comment_count: 342,
-			taken_at: Math.floor(Date.now() / 1000) - 86_400, // 1 day ago
+			taken_at: Math.floor(Date.now() / 1000) - 86_400,
 			media_type: 1,
 		},
 	},
 	{
 		id: 'msg10',
-		timestamp: new Date(Date.now() - 60_000 * 1), // 1 minute ago
+		timestamp: new Date(Date.now() - 60_000 * 1),
 		userId: 'user1',
 		username: 'alice_smith',
 		isOutgoing: true,
@@ -307,13 +511,12 @@ export const mockMessages: Message[] = [
 			},
 			like_count: 89_432,
 			comment_count: 2345,
-			taken_at: Math.floor(Date.now() / 1000) - 43_200, // 12 hours ago
+			taken_at: Math.floor(Date.now() / 1000) - 43_200,
 			media_type: 1,
 		},
 	},
 ];
 
-// Mock threads
 export const mockThreads: Thread[] = [
 	{
 		id: 'thread1',
@@ -328,7 +531,7 @@ export const mockThreads: Thread[] = [
 		title: 'Charlie Brown',
 		users: [mockUsers[2]!],
 		unread: false,
-		lastActivity: new Date(Date.now() - 60_000 * 120), // 2 hours ago
+		lastActivity: new Date(Date.now() - 60_000 * 120),
 		lastMessage: {
 			id: 'msg6',
 			timestamp: new Date(Date.now() - 60_000 * 120),
@@ -349,7 +552,7 @@ export const mockThreads: Thread[] = [
 		title: 'Diana Prince',
 		users: [mockUsers[3]!],
 		unread: true,
-		lastActivity: new Date(Date.now() - 60_000 * 30), // 30 minutes ago
+		lastActivity: new Date(Date.now() - 60_000 * 30),
 		lastMessage: {
 			id: 'msg7',
 			timestamp: new Date(Date.now() - 60_000 * 30),
@@ -367,7 +570,6 @@ export const mockThreads: Thread[] = [
 	},
 ];
 
-// Mock reaction emojis for easy testing
 export const mockEmojis = [
 	'❤️',
 	'😍',
@@ -395,165 +597,12 @@ export const mockEmojis = [
 	'🌟',
 ];
 
-// Mock stories grouped by user for generator pattern testing
-const storyImages: string[] = [
-	'https://sipi.usc.edu/database/preview/misc/4.1.01.png',
-	'https://www.math.hkust.edu.hk/~masyleung/Teaching/CAS/MATLAB/image/images/cameraman.jpg',
-	'https://upload.wikimedia.org/wikipedia/en/thumb/7/7d/Lenna_%28test_image%29.png/500px-Lenna_%28test_image%29.png',
-];
+export const mockStories: Story[] = [];
 
-const timestamp = Date.now();
+for (let i = 0; i < MOCK_USER_COUNT; i++) {
+	mockStories.push(...buildStory(i));
+}
 
-export const mockStories: Story[] = [
-	// Alice's stories
-	{
-		id: 'story1',
-		user: {
-			pk: 1001,
-			username: 'alice_smith',
-			profilePicUrl: storyImages[0]!,
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: storyImages[0]!,
-					width: 1080,
-					height: 1920,
-				},
-			],
-		},
-		taken_at: timestamp,
-		media_type: 1,
-		reel_mentions: [
-			{
-				user: {
-					username: 'bob_johnson',
-					pk: 1002,
-					full_name: 'Bob Johnson',
-					profile_pic_url: storyImages[1]!,
-				},
-			},
-			{
-				user: {
-					username: 'charlie_brown',
-					pk: 1003,
-					full_name: 'Charlie Brown',
-					profile_pic_url: storyImages[2]!,
-				},
-			},
-		],
-	},
-	{
-		id: 'story1b',
-		user: {
-			pk: 1001,
-			username: 'alice_smith',
-			profilePicUrl: storyImages[0]!,
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: storyImages[0]!,
-					width: 1080,
-					height: 1920,
-				},
-			],
-		},
-		taken_at: timestamp,
-		media_type: 1,
-	},
-	// Bob's stories
-	{
-		id: 'story2',
-		user: {
-			pk: 1002,
-			username: 'bob_johnson',
-			profilePicUrl: storyImages[1]!,
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: storyImages[1]!,
-					width: 1080,
-					height: 1920,
-				},
-			],
-		},
-		taken_at: timestamp,
-		media_type: 1,
-	},
-	// Charlie's stories
-	{
-		id: 'story3',
-		user: {
-			pk: 1003,
-			username: 'charlie_brown',
-			profilePicUrl: storyImages[2]!,
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: storyImages[2]!,
-					width: 1080,
-					height: 1920,
-				},
-			],
-		},
-		taken_at: timestamp,
-		media_type: 1,
-	},
-	// Diana's stories
-	{
-		id: 'story4',
-		user: {
-			pk: 1004,
-			username: 'diana_prince',
-			profilePicUrl: storyImages[0]!,
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: storyImages[0]!,
-					width: 1080,
-					height: 1920,
-				},
-			],
-		},
-		taken_at: timestamp,
-		media_type: 1,
-		reel_mentions: [
-			{
-				user: {
-					username: 'alice_smith',
-					pk: 1001,
-					full_name: 'Alice Smith',
-					profile_pic_url: storyImages[0]!,
-				},
-			},
-		],
-	},
-	{
-		id: 'story4b',
-		user: {
-			pk: 1004,
-			username: 'diana_prince',
-			profilePicUrl: storyImages[0]!,
-		},
-		image_versions2: {
-			candidates: [
-				{
-					url: storyImages[0]!,
-					width: 1080,
-					height: 1920,
-				},
-			],
-		},
-		taken_at: timestamp,
-		media_type: 1,
-	},
-];
-
-// Helper functions to generate more data
 export function generateReactions(
 	senderIds: string[],
 	emojiCount = 1,

--- a/source/mocks/mock-data.ts
+++ b/source/mocks/mock-data.ts
@@ -228,7 +228,7 @@ function buildPost(index: number): Post {
 	const hoursAgo = (index + 1) * 2;
 
 	const mockPost: Post = {
-		id: `post${index + 1}`,
+		id: String(100_000_000_000 + index),
 		user: {
 			pk: userPk,
 			username,

--- a/source/mocks/mock-data.ts
+++ b/source/mocks/mock-data.ts
@@ -283,7 +283,6 @@ function buildStory(index: number): Story[] {
 		const mLast = lastNames[mentionIdx]!;
 		const mentionImg = imageUrls[mentionIdx % imageUrls.length]!;
 
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		stories[0]!.reel_mentions = [
 			{
 				user: {

--- a/source/types/instagram.ts
+++ b/source/types/instagram.ts
@@ -164,7 +164,7 @@ export type ListMediaItem<
 	T extends BaseMedia & MediaItemMetadata = BaseMedia & MediaItemMetadata,
 	M = undefined,
 > = {
-	pk: number;
+	pk: string;
 	label: string;
 	content: T[];
 	additional_metadata?: M;

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -212,8 +212,9 @@ export default function ListDetailDisplay<
 		} else if (key.upArrow || input === 'k') {
 			setSelectedIndex(prev => {
 				const newIndex = Math.max(0, prev - 1);
-				if (newIndex < scrollOffset) {
-					setScrollOffset(previous => previous - 1);
+				const margin = Math.floor(viewportSize / 2);
+				if (newIndex < scrollOffset + margin) {
+					setScrollOffset(previous => Math.max(0, previous - 1));
 				}
 
 				return newIndex;
@@ -221,8 +222,14 @@ export default function ListDetailDisplay<
 		} else if (key.downArrow || input === 'j') {
 			setSelectedIndex(prev => {
 				const newIndex = Math.min(prev + 1, combinedItems.length - 1);
-				if (newIndex >= scrollOffset + viewportSize) {
-					setScrollOffset(previous => previous + 1);
+				const margin = Math.floor(viewportSize / 2);
+				if (newIndex >= scrollOffset + margin) {
+					setScrollOffset(previous =>
+						Math.min(
+							previous + 1,
+							Math.max(0, combinedItems.length - viewportSize),
+						),
+					);
 				}
 
 				return newIndex;

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -238,25 +238,38 @@ export default function ListDetailDisplay<
 		} else if (input === 's' && mode === 'story') {
 			setIsSearchMode(true);
 		} else if (key.upArrow || input === 'k') {
-			const newIndex = Math.max(0, selectedIndex - 1);
 			const margin = Math.floor(viewportSize / 2);
 
-			setSelectedIndex(newIndex);
+			setSelectedIndex(prev => {
+				const newIndex = Math.max(0, prev - 1);
 
-			if (newIndex < scrollOffset + margin) {
-				setScrollOffset(prev => Math.max(0, prev - 1));
-			}
+				setScrollOffset(prevScroll => {
+					if (newIndex < prevScroll + margin) {
+						return Math.max(0, prevScroll - 1);
+					}
+
+					return prevScroll;
+				});
+
+				return newIndex;
+			});
 		} else if (key.downArrow || input === 'j') {
-			const newIndex = Math.min(selectedIndex + 1, combinedItems.length - 1);
 			const margin = Math.floor(viewportSize / 2);
+			const maxScroll = Math.max(0, combinedItems.length - viewportSize);
 
-			setSelectedIndex(newIndex);
+			setSelectedIndex(prev => {
+				const newIndex = Math.min(prev + 1, combinedItems.length - 1);
 
-			if (newIndex >= scrollOffset + margin) {
-				setScrollOffset(prev =>
-					Math.min(prev + 1, Math.max(0, combinedItems.length - viewportSize)),
-				);
-			}
+				setScrollOffset(prevScroll => {
+					if (newIndex >= prevScroll + margin) {
+						return Math.min(prevScroll + 1, maxScroll);
+					}
+
+					return prevScroll;
+				});
+
+				return newIndex;
+			});
 		} else if (key.leftArrow || input === 'h') {
 			if (currentItem && currentItem.content.length > 1) {
 				setCarouselIndex(prev => Math.max(0, prev - 1));

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -1,5 +1,13 @@
 import React, {useState, useEffect, useMemo, useRef} from 'react';
-import {Box, Text, useInput, useApp, useStdout} from 'ink';
+import {
+	Box,
+	Text,
+	useInput,
+	useApp,
+	useStdout,
+	type DOMElement,
+	useBoxMetrics,
+} from 'ink';
 import open from 'open';
 import {type ImageProtocolName} from 'ink-picture';
 import {
@@ -71,6 +79,7 @@ export default function ListDetailDisplay<
 	handleSearchSubmit,
 }: Properties<T, M>) {
 	const [selectedIndex, setSelectedIndex] = useState<number>(0);
+	const [scrollOffset, setScrollOffset] = useState(0);
 	const [carouselIndex, setCarouselIndex] = useState<number>(0);
 	const [isSearchMode, setIsSearchMode] = useState(false);
 	const [searchQuery, setSearchQuery] = useState('');
@@ -78,9 +87,15 @@ export default function ListDetailDisplay<
 	const [combinedItems, setCombinedItems] =
 		useState<Array<ListMediaItem<T, M>>>(initialItems);
 	const seenStories = useRef(new Set<string>());
+	const sidebarRef = useRef<DOMElement>(null as unknown as DOMElement);
 
 	const {exit} = useApp();
 	const {stdout} = useStdout();
+
+	const {height: sidebarHeight, hasMeasured} = useBoxMetrics(sidebarRef);
+	const viewportSize = hasMeasured
+		? Math.max(1, Math.floor(sidebarHeight))
+		: 30;
 
 	useEffect(() => {
 		setCombinedItems(initialItems);
@@ -195,9 +210,23 @@ export default function ListDetailDisplay<
 		} else if (input === 's' && mode === 'story') {
 			setIsSearchMode(true);
 		} else if (key.upArrow || input === 'k') {
-			setSelectedIndex(prev => Math.max(0, prev - 1));
+			setSelectedIndex(prev => {
+				const newIndex = Math.max(0, prev - 1);
+				if (newIndex < scrollOffset) {
+					setScrollOffset(previous => previous - 1);
+				}
+
+				return newIndex;
+			});
 		} else if (key.downArrow || input === 'j') {
-			setSelectedIndex(prev => Math.min(prev + 1, combinedItems.length - 1));
+			setSelectedIndex(prev => {
+				const newIndex = Math.min(prev + 1, combinedItems.length - 1);
+				if (newIndex >= scrollOffset + viewportSize) {
+					setScrollOffset(previous => previous + 1);
+				}
+
+				return newIndex;
+			});
 		} else if (key.leftArrow || input === 'h') {
 			if (currentItem && currentItem.content.length > 1) {
 				setCarouselIndex(prev => Math.max(0, prev - 1));
@@ -231,20 +260,28 @@ export default function ListDetailDisplay<
 		[currentContentItem, stdout.columns],
 	);
 
+	const visibleItems = combinedItems.slice(
+		scrollOffset,
+		scrollOffset + viewportSize,
+	);
+
 	const sidebarContent = (
-		<>
-			{combinedItems.map((item, index) => (
-				<Box key={item.pk} height={1} flexShrink={0}>
-					<Text
-						color={index === selectedIndex ? 'blue' : undefined}
-						wrap="truncate-end"
-					>
-						{index === selectedIndex ? '➜ ' : '   '}
-						{item.label}
-					</Text>
-				</Box>
-			))}
-		</>
+		<Box ref={sidebarRef} flexDirection="column" flexGrow={1}>
+			{visibleItems.map((item, index) => {
+				const absoluteIndex = scrollOffset + index;
+				return (
+					<Box key={item.pk} height={1} flexShrink={0}>
+						<Text
+							color={absoluteIndex === selectedIndex ? 'blue' : undefined}
+							wrap="truncate-end"
+						>
+							{absoluteIndex === selectedIndex ? '➜ ' : '   '}
+							{item.label}
+						</Text>
+					</Box>
+				);
+			})}
+		</Box>
 	);
 
 	const mainContent = (

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -98,7 +98,17 @@ export default function ListDetailDisplay<
 		: 30;
 
 	useEffect(() => {
-		setCombinedItems(initialItems);
+		const seen = new Set<(typeof initialItems)[number]['pk']>();
+		setCombinedItems(
+			initialItems.filter(item => {
+				if (seen.has(item.pk)) {
+					return false;
+				}
+
+				seen.add(item.pk);
+				return true;
+			}),
+		);
 	}, [initialItems]);
 
 	const currentItem = combinedItems[selectedIndex];
@@ -180,8 +190,26 @@ export default function ListDetailDisplay<
 		void handleSearchSubmit(searchQuery.trim())
 			.then(result => {
 				if (result) {
-					setCombinedItems(prev => [result, ...prev]);
-					setSelectedIndex(0);
+					const existingIndex = combinedItems.findIndex(
+						item => item.pk === result.pk,
+					);
+					const isExisting = existingIndex !== -1;
+					if (isExisting) {
+						setSelectedIndex(existingIndex);
+						setScrollOffset(
+							Math.max(
+								0,
+								Math.min(
+									existingIndex - Math.floor(viewportSize / 2),
+									Math.max(0, combinedItems.length - viewportSize),
+								),
+							),
+						);
+					} else {
+						setCombinedItems(prev => [result, ...prev]);
+						setSelectedIndex(0);
+						setScrollOffset(0);
+					}
 				} else {
 					setSearchError(`No stories found for user "${searchQuery.trim()}".`);
 				}

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -238,30 +238,25 @@ export default function ListDetailDisplay<
 		} else if (input === 's' && mode === 'story') {
 			setIsSearchMode(true);
 		} else if (key.upArrow || input === 'k') {
-			setSelectedIndex(prev => {
-				const newIndex = Math.max(0, prev - 1);
-				const margin = Math.floor(viewportSize / 2);
-				if (newIndex < scrollOffset + margin) {
-					setScrollOffset(previous => Math.max(0, previous - 1));
-				}
+			const newIndex = Math.max(0, selectedIndex - 1);
+			const margin = Math.floor(viewportSize / 2);
 
-				return newIndex;
-			});
+			setSelectedIndex(newIndex);
+
+			if (newIndex < scrollOffset + margin) {
+				setScrollOffset(prev => Math.max(0, prev - 1));
+			}
 		} else if (key.downArrow || input === 'j') {
-			setSelectedIndex(prev => {
-				const newIndex = Math.min(prev + 1, combinedItems.length - 1);
-				const margin = Math.floor(viewportSize / 2);
-				if (newIndex >= scrollOffset + margin) {
-					setScrollOffset(previous =>
-						Math.min(
-							previous + 1,
-							Math.max(0, combinedItems.length - viewportSize),
-						),
-					);
-				}
+			const newIndex = Math.min(selectedIndex + 1, combinedItems.length - 1);
+			const margin = Math.floor(viewportSize / 2);
 
-				return newIndex;
-			});
+			setSelectedIndex(newIndex);
+
+			if (newIndex >= scrollOffset + margin) {
+				setScrollOffset(prev =>
+					Math.min(prev + 1, Math.max(0, combinedItems.length - viewportSize)),
+				);
+			}
 		} else if (key.leftArrow || input === 'h') {
 			if (currentItem && currentItem.content.length > 1) {
 				setCarouselIndex(prev => Math.max(0, prev - 1));
@@ -280,7 +275,6 @@ export default function ListDetailDisplay<
 			exit();
 		}
 	});
-
 	const currentImageCandidate = currentContentItem
 		? getCurrentImage(currentContentItem)
 		: undefined;

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -88,6 +88,8 @@ export default function ListDetailDisplay<
 		useState<Array<ListMediaItem<T, M>>>(initialItems);
 	const seenStories = useRef(new Set<string>());
 	const sidebarRef = useRef<DOMElement>(null as unknown as DOMElement);
+	const combinedItemsRef = useRef(combinedItems);
+	combinedItemsRef.current = combinedItems;
 
 	const {exit} = useApp();
 	const {stdout} = useStdout();
@@ -208,7 +210,8 @@ export default function ListDetailDisplay<
 		void handleSearchSubmit(searchQuery.trim())
 			.then(result => {
 				if (result) {
-					const existingIndex = combinedItems.findIndex(
+					const currentItems = combinedItemsRef.current;
+					const existingIndex = currentItems.findIndex(
 						item => item.pk === result.pk,
 					);
 					const isExisting = existingIndex !== -1;
@@ -219,7 +222,7 @@ export default function ListDetailDisplay<
 								0,
 								Math.min(
 									existingIndex - Math.floor(viewportSize / 2),
-									Math.max(0, combinedItems.length - viewportSize),
+									Math.max(0, currentItems.length - viewportSize),
 								),
 							),
 						);

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -111,6 +111,24 @@ export default function ListDetailDisplay<
 		);
 	}, [initialItems]);
 
+	useEffect(() => {
+		const clampedIndex = Math.min(
+			selectedIndex,
+			Math.max(0, combinedItems.length - 1),
+		);
+		const maxOffset = Math.max(0, combinedItems.length - viewportSize);
+		let newOffset = Math.min(scrollOffset, maxOffset);
+
+		if (clampedIndex < newOffset) {
+			newOffset = clampedIndex;
+		} else if (clampedIndex >= newOffset + viewportSize && viewportSize > 0) {
+			newOffset = clampedIndex - viewportSize + 1;
+		}
+
+		setSelectedIndex(clampedIndex);
+		setScrollOffset(newOffset);
+	}, [combinedItems.length, viewportSize, scrollOffset, selectedIndex]);
+
 	const currentItem = combinedItems[selectedIndex];
 	const currentContentItem = currentItem?.content[carouselIndex];
 

--- a/source/ui/views/feed-view.tsx
+++ b/source/ui/views/feed-view.tsx
@@ -18,7 +18,7 @@ export default function FeedView({feed}: {readonly feed: FeedData}) {
 	const listItems: Array<ListMediaItem<Post, PostMetadata>> = (
 		feed.posts ?? []
 	).map(post => ({
-		pk: post.user.pk,
+		pk: post.id,
 		label: post.user.username,
 		content: post.carousel_media
 			? (post.carousel_media.map(item => ({

--- a/source/ui/views/story-view.tsx
+++ b/source/ui/views/story-view.tsx
@@ -22,7 +22,7 @@ export default function StoryView({
 		const stories = await client!.getStoriesForUser(undefined, query);
 		if (stories.length > 0 && stories[0]?.user) {
 			const result: ListMediaItem<Story> = {
-				pk: stories[0].user.pk,
+				pk: String(stories[0].user.pk),
 				label: stories[0].user.username,
 				content: stories,
 			};


### PR DESCRIPTION
Closes #212 

## Summary

When `list-detail-display ` contains a long list of items, it may overflow if there isn’t enough vertical space to display all of them.  This PR introduces scrollability to `list-detail-display `, which will move incrementally as the user navigates through the list.


https://github.com/user-attachments/assets/8e696130-c1da-4746-91ad-1349dc8a764e

Furthermore, a bug causing that usernames get duplicated in the list has been fixed, as it was directly causing problems when I was testing the scrolling. I end up modifying slightly the search story by username feature's behavior as I think it was slightly related to the duplication issue. Now, when searching an story, it will change the selected item to the one that match the username searched, instead of displaying it at the top of the list as it was before. 

## Changes
- Midpoint scrolling — When navigating a long list, the viewport now centers on the selected item, keeping context visible instead of snapping to the top.
- Username list scrolling — The username list in the list-detail-display component properly scrolls, making long user lists usable.
- Fix: duplicate items — Resolved a bug where items appeared duplicated in the list. Also changed story search-by-username behavior as it was related to the mentioned bug, and also for a getting a cleaner UX.
- Extended mock data — Added more dummy mock data to both `story` and `feed` so the scrolling list can be tested effectively without a live API.


## Testing

- [x] `npm run build`
- [x] `npm run lint-check` (no warnings)
- [x] `npm test` (115 tests passed)
- [x] Live run testing