### PR TITLE
feat: display avatars in threads list

### DIFF
--- a/source/mocks/mock-data.ts
+++ b/source/mocks/mock-data.ts
@@ -7,38 +7,10 @@ import type {
 	Story,
 } from '../types/instagram.js';
 
-// Mock users
-export const mockUsers: User[] = [
-	{
-		pk: 'user1',
-		username: 'alice_smith',
-		fullName: 'Alice Smith',
-		isVerified: false,
-		profilePicUrl: 'https://sipi.usc.edu/database/preview/misc/4.1.01.png',
-	},
-	{
-		pk: 'user2',
-		username: 'bob_johnson',
-		fullName: 'Bob Johnson',
-		isVerified: true,
-	},
-	{
-		pk: 'user3',
-		username: 'charlie_brown',
-		fullName: 'Charlie Brown',
-		isVerified: false,
-		profilePicUrl:
-			'https://www.math.hkust.edu.hk/~masyleung/Teaching/CAS/MATLAB/image/images/cameraman.jpg',
-	},
-	{
-		pk: 'user4',
-		username: 'diana_prince',
-		fullName: 'Diana Prince',
-		isVerified: true,
-	}
-]
- 
 export const MOCK_USER_COUNT = 75;
+
+const STORY_WIDTH = 1080;
+const STORY_HEIGHT = 1920;
 
 const firstNames = [
 	'Alice',
@@ -198,9 +170,9 @@ const lastNames = [
 
 const imageUrls = [
 	'https://sipi.usc.edu/database/preview/misc/4.1.01.png',
+	'https://sipi.usc.edu/database/preview/misc/4.1.02.png',
 	'https://www.math.hkust.edu.hk/~masyleung/Teaching/CAS/MATLAB/image/images/cameraman.jpg',
 	'https://upload.wikimedia.org/wikipedia/en/thumb/7/7d/Lenna_%28test_image%29.png/500px-Lenna_%28test_image%29.png',
-	'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png',
 ];
 
 const captions = [
@@ -236,8 +208,32 @@ const captions = [
 	'Snowy mountain views 🏔️❄️ #winter #travel',
 ];
 
-const storyWidth = 1080;
-const storyHeight = 1920;
+export const mockEmojis = [
+	'❤️',
+	'😍',
+	'😂',
+	'😮',
+	'😢',
+	'😡',
+	'👍',
+	'👎',
+	'🔥',
+	'💯',
+	'🎉',
+	'✨',
+	'🙏',
+	'💪',
+	'👌',
+	'📸',
+	'📅',
+	'✅',
+	'🤔',
+	'😊',
+	'🥳',
+	'🎊',
+	'💕',
+	'🌟',
+];
 
 function buildUser(index: number): User {
 	const first = firstNames[index]!;
@@ -247,6 +243,8 @@ function buildUser(index: number): User {
 		username: `${first.toLowerCase()}_${last.toLowerCase()}`,
 		fullName: `${first} ${last}`,
 		isVerified: index % 5 === 1,
+		profilePicUrl:
+			index % 4 === 0 ? undefined : imageUrls[index % imageUrls.length],
 	};
 }
 
@@ -258,7 +256,7 @@ function buildPost(index: number): Post {
 	const imgUrl = imageUrls[index % imageUrls.length]!;
 	const hoursAgo = (index + 1) * 2;
 
-	const mockPost: Post = {
+	return {
 		id: String(100_000_000_000 + index),
 		user: {
 			pk: userPk,
@@ -267,14 +265,13 @@ function buildPost(index: number): Post {
 		},
 		caption: {text: captions[index % captions.length]!},
 		image_versions2: {
-			candidates: [{url: imgUrl, width: storyWidth, height: storyHeight}],
+			candidates: [{url: imgUrl, width: STORY_WIDTH, height: STORY_HEIGHT}],
 		},
 		like_count: 50 + Math.floor(Math.random() * 900),
 		comment_count: 3 + Math.floor(Math.random() * 60),
 		taken_at: Date.now() - 60_000 * 60 * hoursAgo,
 		media_type: 1,
 	};
-	return mockPost;
 }
 
 function buildStory(index: number): Story[] {
@@ -289,7 +286,7 @@ function buildStory(index: number): Story[] {
 			id: `story${index + 1}`,
 			user: {pk: userPk, username, profilePicUrl: imgUrl},
 			image_versions2: {
-				candidates: [{url: imgUrl, width: storyWidth, height: storyHeight}],
+				candidates: [{url: imgUrl, width: STORY_WIDTH, height: STORY_HEIGHT}],
 			},
 			taken_at: Date.now(),
 			media_type: 1,
@@ -301,7 +298,7 @@ function buildStory(index: number): Story[] {
 			id: `story${index + 1}b`,
 			user: {pk: userPk, username, profilePicUrl: imgUrl},
 			image_versions2: {
-				candidates: [{url: imgUrl, width: storyWidth, height: storyHeight}],
+				candidates: [{url: imgUrl, width: STORY_WIDTH, height: STORY_HEIGHT}],
 			},
 			taken_at: Date.now(),
 			media_type: 1,
@@ -329,29 +326,27 @@ function buildStory(index: number): Story[] {
 	return stories;
 }
 
-// Hardcoded first 4 — referenced by mockThreads / mockMessages below
-export const mockUsers: User[] = [
-	buildUser(0),
-	buildUser(1),
-	buildUser(2),
-	buildUser(3),
-];
+// Core User List (first 4 hardcoded references for threads/messages)
+export const mockUsers: User[] = Array.from({length: MOCK_USER_COUNT}, (_, i) =>
+	buildUser(i),
+);
 
-for (let i = 4; i < MOCK_USER_COUNT; i++) {
-	mockUsers.push(buildUser(i));
-}
-
-export const mockPosts: Post[] = [];
-
-for (let i = 0; i < MOCK_USER_COUNT; i++) {
-	mockPosts.push(buildPost(i));
-}
+// Core Posts & Feed List
+export const mockPosts: Post[] = Array.from({length: MOCK_USER_COUNT}, (_, i) =>
+	buildPost(i),
+);
 
 export const mockFeed = {
 	posts: mockPosts,
 };
 
-// Mock messages
+// Core Stories List
+export const mockStories: Story[] = Array.from(
+	{length: MOCK_USER_COUNT},
+	(_, i) => i,
+).flatMap(i => buildStory(i));
+
+// Static Messaging Mock Dataset
 export const mockMessages: Message[] = [
 	{
 		id: 'msg1',
@@ -548,7 +543,7 @@ export const mockMessages: Message[] = [
 	// Last entry needs to be text for testing convenience
 	{
 		id: 'msg11',
-		timestamp: new Date(Date.now()),
+		timestamp: new Date(),
 		userId: 'user1',
 		username: 'alice_smith',
 		isOutgoing: true,
@@ -558,6 +553,7 @@ export const mockMessages: Message[] = [
 	},
 ];
 
+// Core Thread Mock Dataset
 export const mockThreads: Thread[] = [
 	{
 		id: 'thread1',
@@ -610,39 +606,6 @@ export const mockThreads: Thread[] = [
 		},
 	},
 ];
-
-export const mockEmojis = [
-	'❤️',
-	'😍',
-	'😂',
-	'😮',
-	'😢',
-	'😡',
-	'👍',
-	'👎',
-	'🔥',
-	'💯',
-	'🎉',
-	'✨',
-	'🙏',
-	'💪',
-	'👌',
-	'📸',
-	'📅',
-	'✅',
-	'🤔',
-	'😊',
-	'🥳',
-	'🎊',
-	'💕',
-	'🌟',
-];
-
-export const mockStories: Story[] = [];
-
-for (let i = 0; i < MOCK_USER_COUNT; i++) {
-	mockStories.push(...buildStory(i));
-}
 
 export function generateReactions(
 	senderIds: string[],

--- a/source/mocks/mock-data.ts
+++ b/source/mocks/mock-data.ts
@@ -14,6 +14,7 @@ export const mockUsers: User[] = [
 		username: 'alice_smith',
 		fullName: 'Alice Smith',
 		isVerified: false,
+		profilePicUrl: 'https://sipi.usc.edu/database/preview/misc/4.1.01.png',
 	},
 	{
 		pk: 'user2',
@@ -26,6 +27,8 @@ export const mockUsers: User[] = [
 		username: 'charlie_brown',
 		fullName: 'Charlie Brown',
 		isVerified: false,
+		profilePicUrl:
+			'https://www.math.hkust.edu.hk/~masyleung/Teaching/CAS/MATLAB/image/images/cameraman.jpg',
 	},
 	{
 		pk: 'user4',

--- a/source/ui/components/thread-item.tsx
+++ b/source/ui/components/thread-item.tsx
@@ -7,9 +7,14 @@ import {useImageProtocol} from '../hooks/use-image-protocol.js';
 type ThreadItemProperties = {
 	readonly thread: Thread;
 	readonly isSelected: boolean;
+	readonly isHovered: boolean;
 };
 
-export default function ThreadItem({thread, isSelected}: ThreadItemProperties) {
+export default function ThreadItem({
+	thread,
+	isSelected,
+	isHovered,
+}: ThreadItemProperties) {
 	const imageProtocol = useImageProtocol();
 	const formatTime = (date: Date) => {
 		const now = new Date();
@@ -66,11 +71,10 @@ export default function ThreadItem({thread, isSelected}: ThreadItemProperties) {
 	return (
 		<Box
 			paddingX={1}
-			paddingY={0}
+			paddingY={1}
 			width="100%"
 			flexDirection="row"
-			borderStyle={isSelected ? 'round' : undefined}
-			borderColor={isSelected ? 'cyan' : undefined}
+			backgroundColor={isSelected ? '#3a3a3a' : isHovered ? 'gray' : undefined}
 		>
 			{threadAvatar && (
 				<Box marginRight={1}>

--- a/source/ui/components/thread-item.tsx
+++ b/source/ui/components/thread-item.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Box, Text} from 'ink';
+import Image from 'ink-picture';
 import type {Message, Thread} from '../../types/instagram.js';
+import {useImageProtocol} from '../hooks/use-image-protocol.js';
 
 type ThreadItemProperties = {
 	readonly thread: Thread;
@@ -8,6 +10,7 @@ type ThreadItemProperties = {
 };
 
 export default function ThreadItem({thread, isSelected}: ThreadItemProperties) {
+	const imageProtocol = useImageProtocol();
 	const formatTime = (date: Date) => {
 		const now = new Date();
 		const diff = now.getTime() - date.getTime();
@@ -58,44 +61,58 @@ export default function ThreadItem({thread, isSelected}: ThreadItemProperties) {
 		? getLastMessageText(thread.lastMessage)
 		: '';
 
+	const threadAvatar = thread.users[0]?.profilePicUrl;
+
 	return (
 		<Box
 			paddingX={1}
 			paddingY={0}
 			width="100%"
-			flexDirection="column"
+			flexDirection="row"
 			borderStyle={isSelected ? 'round' : undefined}
 			borderColor={isSelected ? 'cyan' : undefined}
 		>
-			{/* Top Row: Title, Unread, Time */}
-			<Box justifyContent="space-between">
-				<Box flexShrink={1} marginRight={2}>
-					<Text
-						bold={isSelected}
-						color={isSelected ? 'cyan' : undefined}
-						wrap="truncate"
-					>
-						{thread.title}
-					</Text>
-				</Box>
-				<Box>
-					{thread.unread && (
-						<Text bold color="green">
-							●{' '}
-						</Text>
-					)}
-					<Text dimColor>{formatTime(thread.lastActivity)}</Text>
-				</Box>
-			</Box>
-
-			{/* Bottom Row: Last Message */}
-			{lastMessageText && (
-				<Box>
-					<Text dimColor wrap="truncate">
-						{lastMessageText.replaceAll(/[\n\r]+/g, ' ')}
-					</Text>
+			{threadAvatar && (
+				<Box marginRight={1}>
+					<Image
+						src={threadAvatar}
+						width={4}
+						height={2}
+						protocol={{full: imageProtocol}}
+					/>
 				</Box>
 			)}
+			<Box flexDirection="column">
+				{/* Top Row: Title, Unread, Time */}
+				<Box justifyContent="space-between">
+					<Box flexShrink={1} marginRight={2}>
+						<Text
+							bold={isSelected}
+							color={isSelected ? 'cyan' : undefined}
+							wrap="truncate"
+						>
+							{thread.title}
+						</Text>
+					</Box>
+					<Box>
+						{thread.unread && (
+							<Text bold color="green">
+								●{' '}
+							</Text>
+						)}
+						<Text dimColor>{formatTime(thread.lastActivity)}</Text>
+					</Box>
+				</Box>
+
+				{/* Bottom Row: Last Message */}
+				{lastMessageText && (
+					<Box>
+						<Text dimColor wrap="truncate">
+							{lastMessageText.replaceAll(/[\n\r]+/g, ' ')}
+						</Text>
+					</Box>
+				)}
+			</Box>
 		</Box>
 	);
 }

--- a/source/ui/components/thread-list.tsx
+++ b/source/ui/components/thread-list.tsx
@@ -24,6 +24,7 @@ export default function ThreadList({
 }: ThreadListProperties) {
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const [scrollOffset, setScrollOffset] = useState(0);
+	const [hoveredIndex, setHoveredIndex] = useState(-1);
 
 	const containerReference = useRef<DOMElement>(null as unknown as DOMElement);
 	// Item height is constant because content is always truncated to fit the height
@@ -101,6 +102,28 @@ export default function ThreadList({
 					return true;
 				}
 
+				// Track hover position for mouse hover highlighting
+				if (event.name === 'move') {
+					const containerNode = containerReference.current;
+					if (!containerNode) return false;
+
+					const clickX = event.col - 1;
+					const clickY = event.row - 1;
+
+					const containerLayout = measureAbsoluteLayout(containerNode);
+					const relativeX = clickX - containerLayout.x;
+					const relativeY = clickY - containerLayout.y;
+
+					const visibleIndex = findChildAtPosition(
+						containerNode,
+						relativeX,
+						relativeY,
+					);
+
+					setHoveredIndex(visibleIndex >= 0 ? scrollOffset + visibleIndex : -1);
+					return false;
+				}
+
 				// Click to select and open a thread
 				if (event.name === 'left-press') {
 					const containerNode = containerReference.current;
@@ -154,18 +177,13 @@ export default function ThreadList({
 			{visibleThreads.map((thread, index) => {
 				// The actual index in the full threads array
 				const absoluteIndex = scrollOffset + index;
-				const isLastItem = index === visibleThreads.length - 1;
 
 				return (
-					<Box
-						key={thread.id}
-						flexDirection="column"
-						marginBottom={isLastItem ? 0 : 1}
-						flexShrink={0}
-					>
+					<Box key={thread.id} flexDirection="column" flexShrink={0}>
 						<ThreadItem
 							thread={thread}
 							isSelected={absoluteIndex === selectedIndex}
+							isHovered={absoluteIndex === hoveredIndex}
 						/>
 					</Box>
 				);

--- a/source/utils/mouse.ts
+++ b/source/utils/mouse.ts
@@ -54,14 +54,14 @@ export type MouseHandler = (event: MouseEvent) => void | boolean;
 
 // ── Escape sequence helpers ──────────────────────────────────────────────────
 
-/** Write to stdout to enable mouse button-event tracking + SGR extended mode. */
+/** Write to stdout to enable mouse any-event tracking + SGR extended mode. */
 export function enableMouseTracking(stdout: NodeJS.WriteStream): void {
-	stdout.write('\u001B[?1002h\u001B[?1006h');
+	stdout.write('\u001B[?1003h\u001B[?1006h');
 }
 
 /** Write to stdout to disable mouse tracking. */
 export function disableMouseTracking(stdout: NodeJS.WriteStream): void {
-	stdout.write('\u001B[?1006l\u001B[?1002l');
+	stdout.write('\u001B[?1006l\u001B[?1003l');
 }
 
 // ── Parsing ──────────────────────────────────────────────────────────────────

--- a/tests/thread-item.test.tsx
+++ b/tests/thread-item.test.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import test from 'ava';
+import chalk from 'chalk';
 import {render} from 'ink-testing-library';
 import ThreadItem from '../source/ui/components/thread-item.js';
 import MessageList from '../source/ui/components/message-list.js';
@@ -11,7 +12,7 @@ test('ThreadItem renders thread title and unread indicator', t => {
 	const unreadThread = mockThreads.find(th => th.unread)!;
 
 	const {lastFrame, unmount} = render(
-		<ThreadItem thread={unreadThread} isSelected={false} />,
+		<ThreadItem thread={unreadThread} isSelected={false} isHovered={false} />,
 	);
 	const output = lastFrame();
 
@@ -24,7 +25,7 @@ test("Read ThreadItem doesn't display unread indicator", t => {
 	const readThread = mockThreads.find(th => !th.unread)!;
 
 	const {lastFrame, unmount} = render(
-		<ThreadItem isSelected thread={readThread} />,
+		<ThreadItem isSelected thread={readThread} isHovered={false} />,
 	);
 	const output = lastFrame();
 
@@ -36,11 +37,12 @@ test("Read ThreadItem doesn't display unread indicator", t => {
 	unmount();
 });
 
-test('ThreadItem renders selected state', t => {
+// eslint-disable-next-line ava/no-skip-test
+test.skip('ThreadItem renders selected state', t => {
 	const thread = mockThreads[0]!;
 
 	const {lastFrame, unmount} = render(
-		<ThreadItem isSelected thread={thread} />,
+		<ThreadItem isSelected thread={thread} isHovered={false} />,
 	);
 	const output = lastFrame();
 

--- a/tests/thread-item.test.tsx
+++ b/tests/thread-item.test.tsx
@@ -8,6 +8,10 @@ import ThreadItem from '../source/ui/components/thread-item.js';
 import MessageList from '../source/ui/components/message-list.js';
 import {mockThreads, mockMessages} from '../source/mocks/mock-data.js';
 
+// Force chalk to emit ANSI color codes so the cursor highlight is visible in
+// the captured frame output. This must be set before any rendering occurs.
+chalk.level = 3;
+
 test('ThreadItem renders thread title and unread indicator', t => {
 	const unreadThread = mockThreads.find(th => th.unread)!;
 
@@ -37,17 +41,15 @@ test("Read ThreadItem doesn't display unread indicator", t => {
 	unmount();
 });
 
-// eslint-disable-next-line ava/no-skip-test
-test.skip('ThreadItem renders selected state', t => {
+test('ThreadItem renders selected state', t => {
 	const thread = mockThreads[0]!;
 
 	const {lastFrame, unmount} = render(
 		<ThreadItem isSelected thread={thread} isHovered={false} />,
 	);
 	const output = lastFrame();
-
-	// Selected threads have rounded corners in the Box component
-	t.truthy(output?.includes('\u2500'), 'Should display selected state');
+	// Selected threads are highlighted with gray background
+	t.truthy(output?.includes('\u001B[48;2;58;58;58m'));
 	unmount();
 });
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/7b5491bf-9890-497b-a346-0adaffdae152

- Added a 4x2 avatar image to each thread item
  - The avatar is the profile picture of the other user for DMs, and the profile picture of one of the participants in a group (since Instagram's API doesn't seem to include the group cover picture in the inbox endpoint)
- Reworked the thread list display to use background color to highlight the selected thread and threads with mouse hover respectively


