### PR TITLE
feature: display full name in feed and stories + small UI fixes

### DIFF
--- a/source/client.ts
+++ b/source/client.ts
@@ -997,6 +997,7 @@ export class InstagramClient extends EventEmitter {
 				.map(item => ({
 					pk: String(item.user.pk),
 					label: item.user.username ?? `User_${item.user.pk}`,
+					fullName: item.user.full_name,
 					content: [], // Stories will be lazy-loaded
 				}));
 
@@ -1264,6 +1265,7 @@ export class InstagramClient extends EventEmitter {
 			user: {
 				pk: item.user.pk,
 				username: item.user.username,
+				full_name: item.user.full_name,
 				profilePicUrl: item.user.profile_pic_url,
 			},
 			// We validated that this field exists on the returned object

--- a/source/mocks/mock-client.ts
+++ b/source/mocks/mock-client.ts
@@ -474,7 +474,7 @@ class MockClient extends EventEmitter {
 			if (user && !seen.has(user.pk)) {
 				seen.add(user.pk);
 				result.push({
-					pk: user.pk,
+					pk: `${user.pk}`,
 					label: user.username,
 					fullName: user.full_name,
 					content: [],

--- a/source/mocks/mock-client.ts
+++ b/source/mocks/mock-client.ts
@@ -466,18 +466,23 @@ class MockClient extends EventEmitter {
 			setTimeout(resolve, 100);
 		});
 
-		const usersWithStories = new Map<number, User>();
+		const seen = new Set<number>();
+		const result: Array<ListMediaItem<Story>> = [];
+
 		for (const story of mockStories) {
-			if (story.user && !usersWithStories.has(story.user.pk)) {
-				usersWithStories.set(story.user.pk, story.user as unknown as User);
+			const {user} = story;
+			if (user && !seen.has(user.pk)) {
+				seen.add(user.pk);
+				result.push({
+					pk: user.pk,
+					label: user.username,
+					fullName: user.full_name,
+					content: [],
+				});
 			}
 		}
 
-		return [...usersWithStories.values()].map(user => ({
-			pk: typeof user.pk === 'string' ? user.pk : String(user.pk),
-			label: user.username,
-			content: [],
-		}));
+		return result;
 	}
 
 	async getStoriesForUser(

--- a/source/mocks/mock-data.ts
+++ b/source/mocks/mock-data.ts
@@ -261,6 +261,7 @@ function buildPost(index: number): Post {
 		user: {
 			pk: userPk,
 			username,
+			full_name: `${first} ${last}`,
 			profilePicUrl: index % 3 === 0 ? undefined : imgUrl,
 		},
 		caption: {text: captions[index % captions.length]!},
@@ -284,7 +285,12 @@ function buildStory(index: number): Story[] {
 	const stories: Story[] = [
 		{
 			id: `story${index + 1}`,
-			user: {pk: userPk, username, profilePicUrl: imgUrl},
+			user: {
+				pk: userPk,
+				username,
+				full_name: `${first} ${last}`,
+				profilePicUrl: imgUrl,
+			},
 			image_versions2: {
 				candidates: [{url: imgUrl, width: STORY_WIDTH, height: STORY_HEIGHT}],
 			},
@@ -296,7 +302,12 @@ function buildStory(index: number): Story[] {
 	if (index % 3 === 0) {
 		stories.push({
 			id: `story${index + 1}b`,
-			user: {pk: userPk, username, profilePicUrl: imgUrl},
+			user: {
+				pk: userPk,
+				username,
+				full_name: `${first} ${last}`,
+				profilePicUrl: imgUrl,
+			},
 			image_versions2: {
 				candidates: [{url: imgUrl, width: STORY_WIDTH, height: STORY_HEIGHT}],
 			},

--- a/source/types/instagram.ts
+++ b/source/types/instagram.ts
@@ -155,6 +155,7 @@ export type MediaItemMetadata = {
 	user: {
 		pk: number;
 		username: string;
+		full_name?: string;
 		profilePicUrl?: string;
 	};
 	taken_at: number;
@@ -166,6 +167,7 @@ export type ListMediaItem<
 > = {
 	pk: string;
 	label: string;
+	fullName?: string;
 	content: T[];
 	additional_metadata?: M;
 };

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -401,7 +401,12 @@ export default function ListDetailDisplay<
 						justifyContent="flex-start"
 					>
 						<Box flexDirection="column" gap={1} marginBottom={1}>
-							<Text color="green">👤 {currentItem?.label ?? 'Unknown'}</Text>
+							<Text color="green" wrap="truncate-end">
+								👤 @{currentItem?.label ?? 'Unknown'}
+								{currentItem?.fullName && stdout.columns >= 100
+									? ` (${currentItem.fullName})`
+									: ''}
+							</Text>
 
 							{currentContentItem && 'taken_at' in currentContentItem && (
 								<Text color="gray">

--- a/source/ui/components/list-detail-display.tsx
+++ b/source/ui/components/list-detail-display.tsx
@@ -359,12 +359,6 @@ export default function ListDetailDisplay<
 						onChange={setSearchQuery}
 					/>
 				</Box>
-			) : mode === 'story' ? (
-				<Box marginBottom={1}>
-					<Text dimColor>
-						Press &apos;s&apos; to search for a user&apos;s stories
-					</Text>
-				</Box>
 			) : null}
 			{searchError && (
 				<Box marginBottom={1}>
@@ -473,7 +467,7 @@ export default function ListDetailDisplay<
 			mainContent={mainContent}
 			footerText={
 				mode === 'story'
-					? 'j/k: users, h/l: stories, o: open, s: search, Esc: quit'
+					? 'j/k: users, h/l: stories, o: open, s: search user, Esc: quit'
 					: 'j/k: navigate posts, h/l: navigate carousel, o: open, Esc: quit'
 			}
 		/>

--- a/source/ui/components/media-pane.tsx
+++ b/source/ui/components/media-pane.tsx
@@ -66,16 +66,24 @@ export default function MediaPane({
 				<Text color="red">No media available</Text>
 			)}
 
-			<Text>{mediaType === 2 ? '▶ Video' : ''}</Text>
-			{carouselCount && carouselCount > 1 ? (
-				<Text dimColor>
-					<Text color={carouselIndex === 0 ? 'gray' : 'white'}>←</Text>{' '}
-					{(carouselIndex ?? 0) + 1}/{carouselCount}{' '}
-					<Text color={carouselIndex === carouselCount - 1 ? 'gray' : 'white'}>
-						→
-					</Text>
-				</Text>
-			) : null}
+			<Text>{mediaType === 2 ? '▶ Video ' : ' '}</Text>
+			<Text dimColor>
+				{carouselCount && carouselCount > 1 ? (
+					<>
+						<Text color={carouselIndex === 0 ? 'gray' : 'white'}>←</Text>{' '}
+						{String((carouselIndex ?? 0) + 1).padStart(2)}/
+						{String(carouselCount).padStart(2)}{' '}
+						<Text
+							color={carouselIndex === carouselCount - 1 ? 'gray' : 'white'}
+						>
+							{' '}
+							→
+						</Text>
+					</>
+				) : (
+					' '
+				)}
+			</Text>
 		</Box>
 	);
 }

--- a/source/ui/components/media-pane.tsx
+++ b/source/ui/components/media-pane.tsx
@@ -68,8 +68,12 @@ export default function MediaPane({
 
 			<Text>{mediaType === 2 ? '▶ Video' : ''}</Text>
 			{carouselCount && carouselCount > 1 ? (
-				<Text color="gray">
-					Carousel {(carouselIndex ?? 0) + 1} of {carouselCount}
+				<Text dimColor>
+					<Text color={carouselIndex === 0 ? 'gray' : 'white'}>←</Text>{' '}
+					{(carouselIndex ?? 0) + 1}/{carouselCount}{' '}
+					<Text color={carouselIndex === carouselCount - 1 ? 'gray' : 'white'}>
+						→
+					</Text>
 				</Text>
 			) : null}
 		</Box>

--- a/source/ui/components/media-pane.tsx
+++ b/source/ui/components/media-pane.tsx
@@ -70,11 +70,13 @@ export default function MediaPane({
 			<Text dimColor>
 				{carouselCount && carouselCount > 1 ? (
 					<>
-						<Text color={carouselIndex === 0 ? 'gray' : 'white'}>←</Text>{' '}
+						<Text color={(carouselIndex ?? 0) === 0 ? 'gray' : 'white'}>←</Text>{' '}
 						{String((carouselIndex ?? 0) + 1).padStart(2)}/
 						{String(carouselCount).padStart(2)}{' '}
 						<Text
-							color={carouselIndex === carouselCount - 1 ? 'gray' : 'white'}
+							color={
+								(carouselIndex ?? 0) === carouselCount - 1 ? 'gray' : 'white'
+							}
 						>
 							{' '}
 							→

--- a/source/ui/views/feed-view.tsx
+++ b/source/ui/views/feed-view.tsx
@@ -20,6 +20,7 @@ export default function FeedView({feed}: {readonly feed: FeedData}) {
 	).map(post => ({
 		pk: post.id,
 		label: post.user.username,
+		fullName: post.user.full_name,
 		content: post.carousel_media
 			? (post.carousel_media.map(item => ({
 					...item,

--- a/source/ui/views/story-view.tsx
+++ b/source/ui/views/story-view.tsx
@@ -24,6 +24,7 @@ export default function StoryView({
 			const result: ListMediaItem<Story> = {
 				pk: String(stories[0].user.pk),
 				label: stories[0].user.username,
+				fullName: stories[0].user.full_name,
 				content: stories,
 			};
 			return result;


### PR DESCRIPTION
Closes #365 

## Summary
Small UI quality-of-life improvements across the feed and stories display: user full names now appear in the sidebar, the carousel indicator has a cleaner format, the instructional search text at the top was removed to reduce clutter, and a layout jitter bug in the media pane is fixed.

<img width="932" height="491" alt="image" src="https://github.com/user-attachments/assets/7c5a4749-e2a5-4169-a118-2f2c864f7e1c" />


<img width="96" height="46" alt="image" src="https://github.com/user-attachments/assets/5bb38266-aa7a-4a52-8de7-f2f64e069a8d" />

## Changes
- Display full names — The sidebar header now shows @username (Full Name) when the terminal is at least 100 columns wide. fullName/full_name was plumbed through ListMediaItem, MediaItemMetadata, the client layer, and views.
- Carousel index formatting — Replaced "Carousel X of Y" with "← XX/YY →" for a more compact look; arrows dim at the first/last item to indicate boundary.
- Remove instructional text — Removed the "Press 's' to search for a user's stories" hint from the top of the story view to reduce visual noise (the footer already shows s: search user).
- Fix media pane frame displacement — The footer text (video indicator, carousel counter) now always occupies the same vertical space, preventing the media frame from jumping up/down when these elements appear or disappear.
## Testing
- npm run build
- npm run lint-check (no warnings)
- npm test (all tests passed)
- Live run testing