### PR TITLE
fix: use objectFit=cover on all images to keep aspect ratio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"ink": "^7.0.0",
 				"ink-big-text": "^2.0.0",
 				"ink-gradient": "^3.0.0",
-				"ink-picture": "^2.0.1",
+				"ink-picture": "^2.1.0",
 				"ink-testing-library": "^4.0.0",
 				"instagram_mqtt": "^1.2.3",
 				"instagram-private-api": "^1.46.1",
@@ -6676,9 +6676,9 @@
 			}
 		},
 		"node_modules/ink-picture": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ink-picture/-/ink-picture-2.0.1.tgz",
-			"integrity": "sha512-8Yo3vTJ9HWB5nSCbMTngk6H1/PSYOmQp4fbrwKCxyCACiHajp6BDO/vdOrUWFjwPfc89qvIrmgs5kantkqidCw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ink-picture/-/ink-picture-2.1.0.tgz",
+			"integrity": "sha512-5rCEO+YGPJu8NXssW9xoRJVWaitzJh1bguf3Fff7LaFbyx2Ek2F7/Eb/CNvLYErQB8ZkiuxOOJoILJOE6UQeWw==",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"ink": "^7.0.0",
 		"ink-big-text": "^2.0.0",
 		"ink-gradient": "^3.0.0",
-		"ink-picture": "^2.0.1",
+		"ink-picture": "^2.1.0",
 		"ink-testing-library": "^4.0.0",
 		"instagram_mqtt": "^1.2.3",
 		"instagram-private-api": "^1.46.1",

--- a/source/ui/components/media-pane.tsx
+++ b/source/ui/components/media-pane.tsx
@@ -58,7 +58,12 @@ export default function MediaPane({
 					width={dynamicImageSize.width}
 					height={dynamicImageSize.height}
 				>
-					<Image src={imageUrl} alt={altText} protocol={{full: protocol}} />
+					<Image
+						src={imageUrl}
+						alt={altText}
+						objectFit="contain"
+						protocol={{full: protocol}}
+					/>
 				</Box>
 			) : mediaType === 2 ? (
 				<Text color="yellow">▶ Video (no preview)</Text>

--- a/source/ui/components/message-list.tsx
+++ b/source/ui/components/message-list.tsx
@@ -70,6 +70,7 @@ export default function MessageList({
 							<Image
 								src={imageUrl}
 								alt="Sent image"
+								objectFit="contain"
 								protocol={{full: imageProtocol}}
 								getVisibility={({
 									position,

--- a/source/ui/components/thread-item.tsx
+++ b/source/ui/components/thread-item.tsx
@@ -82,6 +82,7 @@ export default function ThreadItem({
 						src={threadAvatar}
 						width={4}
 						height={2}
+						objectFit="contain"
 						protocol={{full: imageProtocol}}
 					/>
 				</Box>

--- a/source/ui/views/profile-view.tsx
+++ b/source/ui/views/profile-view.tsx
@@ -33,6 +33,7 @@ export default function ProfileView({profile, imageProtocol}: Props) {
 						alt={profile.username}
 						width={20}
 						height={10}
+						objectFit="contain"
 						protocol={{full: imageProtocol}}
 					/>
 				</Box>


### PR DESCRIPTION
- Upgraded the `ink-picture` package from `2.0.1` to `2.1.0`.
- Added `objectFit="contain"` to all `Image` components in the codebase to prevent image distortion and maintain aspect ratio. Images will be centered in their containers with transparent spacing on both sides if necessary.
