### PR TITLE
chore(ci): pin npm to 11.x to avoid sigstore bundling bug in npm 12.0.0 

### DIFF
--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Update npm
         # Ensure npm 11.5.1 or later for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies and build
         run: npm ci && npm run build


### PR DESCRIPTION
Upstream issue with npm: https://github.com/npm/cli/issues/9722 😅 

This has been failing our release pipeline when publishing