### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ We contributed the following extensions to the [Ink](https://github.com/vadimdem
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=supreme-gg-gg/instagram-cli&type=date&legend=top-left)](https://www.star-history.com/#supreme-gg-gg/instagram-cli&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=supreme-gg-gg/instagram-cli&type=date&legend=top-left)](https://star-history.dera.page/#supreme-gg-gg/instagram-cli&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart in the README is currently broken due to changes in GitHub's stargazer API. This PR updates the chart to use star-history.dera.page, which relies on an alternative data source that requires no API token and serves both the chart and the frontend from the same domain.