### PR TITLE
fix: quicker media loading by remounting the Image component on URL change

### DIFF
--- a/source/ui/components/media-pane.tsx
+++ b/source/ui/components/media-pane.tsx
@@ -59,6 +59,7 @@ export default function MediaPane({
 					height={dynamicImageSize.height}
 				>
 					<Image
+						key={imageUrl}
 						src={imageUrl}
 						alt={altText}
 						objectFit="contain"


### PR DESCRIPTION
Related to #385

## Summary

Whenever the media URL changed (switching between carousel items, moving from one story/post to the next), `ink-picture` kept reusing the render of the previously loaded image instead of loading the new one. That made media loading feel laggy and sometimes showed the wrong image.

The fix is a one-liner: add a `key` to the `<Image>` component so React remounts it from scratch whenever `imageUrl` changes, forcing it to pick up the new URL immediately.


https://github.com/user-attachments/assets/52d5a842-db6c-4534-9dd1-b1fabff3f236



## Testing

- [x] `npm run build`
- [x] `npm run lint-check`
- [x] `npm test`
- [x] Live run testing